### PR TITLE
fix: `componenent` -> `component`

### DIFF
--- a/website/pages/blog/unleash-the-power-of-fragments-with-graphql-codegen.mdx
+++ b/website/pages/blog/unleash-the-power-of-fragments-with-graphql-codegen.mdx
@@ -56,7 +56,7 @@ export function Avatar(props: AvatarProps) {
 }
 ```
 
-**Data (fragment) masking.** Ensure that a componenent can only access the data defined in its
+**Data (fragment) masking.** Ensure that a component can only access the data defined in its
 fragment definitions in order to keep the component a self-contained building block that can be
 re-used.
 


### PR DESCRIPTION
Found a typo while reading the blog post.