### PR TITLE
fix vale config

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,8 +4,6 @@ MinAlertLevel = suggestion
 
 Packages = write-good, alex, Readability
 
-Vocab = Blog
-
 [*.mdx]
 
 IgnoredScopes = script, code, tt, pre, figure, blockquote


### PR DESCRIPTION
The `Blog` directory was deleted in https://github.com/the-guild-org/website/pull/1423/files (the tool now crashes in PR as it tries to find the Blog vocabulary).