### PR TITLE
Add `title` for each tag page

### DIFF
--- a/website/pages/blog.mdx
+++ b/website/pages/blog.mdx
@@ -9,7 +9,7 @@ import { BlogCardList, Heading, Newsletter, TagList } from '@/components'
 import { HeroSection } from '@/hero-section'
 import { allBlogs } from '../lib/all-blogs'
 import { asArray } from '../lib/as-array'
-import Head from 'next/head';
+import Head from 'next/head'
 
 
 export function extractRelevantTags(articles) {
@@ -42,12 +42,13 @@ export default function Blog() {
         tagsFilter.length === 0 || asArray(article.tags).some(tag => tagsFilter.includes(tag))
     )
   }
+  const title = tagsFilter.length ? `Blog - ${tagsFilter.join(', ')} (The Guild)` : 'Blog - (The Guild)'
 
-  const canonicalUrl = `https://the-guild.dev/blog${tagsFilter.length ? `/tag/${tagsFilter.join(',')}` : ''}`
   return (
     <>
+
       <Head>
-        <link rel="canonical" href={canonicalUrl} />
+        <title>{title}</title>
       </Head>
       <HeroSection>
         <Heading>The Guild's blog</Heading>

--- a/website/pages/blog.mdx
+++ b/website/pages/blog.mdx
@@ -11,7 +11,6 @@ import { allBlogs } from '../lib/all-blogs'
 import { asArray } from '../lib/as-array'
 import Head from 'next/head'
 
-
 export function extractRelevantTags(articles) {
   const allTags = articles.flatMap(article => article.tags || [])
   const map = Object.create(null)
@@ -44,8 +43,7 @@ export default function Blog() {
   }
   const title = tagsFilter.length ? `Blog - ${tagsFilter.join(', ')} (The Guild)` : 'Blog - (The Guild)'
 
-  return (
-    <>
+return ( <>
 
       <Head>
         <title>{title}</title>
@@ -59,5 +57,5 @@ export default function Blog() {
         {<BlogCardList articles={articles} />}
       </div>
     </>
-  )
-}
+
+) }

--- a/website/pages/blog.mdx
+++ b/website/pages/blog.mdx
@@ -9,6 +9,8 @@ import { BlogCardList, Heading, Newsletter, TagList } from '@/components'
 import { HeroSection } from '@/hero-section'
 import { allBlogs } from '../lib/all-blogs'
 import { asArray } from '../lib/as-array'
+import Head from 'next/head';
+
 
 export function extractRelevantTags(articles) {
   const allTags = articles.flatMap(article => article.tags || [])
@@ -40,8 +42,13 @@ export default function Blog() {
         tagsFilter.length === 0 || asArray(article.tags).some(tag => tagsFilter.includes(tag))
     )
   }
+
+  const canonicalUrl = `https://the-guild.dev/blog${tagsFilter.length ? `/tag/${tagsFilter.join(',')}` : ''}`
   return (
     <>
+      <Head>
+        <link rel="canonical" href={canonicalUrl} />
+      </Head>
       <HeroSection>
         <Heading>The Guild's blog</Heading>
       </HeroSection>


### PR DESCRIPTION
This issue come from Ahrefs, this is should fix over 60 errors with the title: [Duplicate pages without canonical](https://app.ahrefs.com/site-audit/4153726/79/data-explorer?columns=pageRating%2Curl%2Ctraffic%2Cdepth%2Ccompliant%2Ccanonical%2CincomingCanonical%2ChashContent%2CduplicateContent%2Ctitle%2CmetaDescription%2Ch1&filterId=f0b94dd8f12b3de78caad15a13b864b1&issueId=c64d5626-d0f4-11e7-8ed1-001e67ed4656&sorting=-hashContent)