### PR TITLE
remove dash for products

### DIFF
--- a/website/ui/hero.tsx
+++ b/website/ui/hero.tsx
@@ -63,7 +63,7 @@ export function Hero() {
           }}
         >
           <PRODUCTS.HIVE.logo className={clsx('h-7 w-auto', !isHive && 'fill-current')} />
-          GraphQL-Hive
+          GraphQL Hive
         </button>
         <button
           className={clsx(
@@ -76,7 +76,7 @@ export function Hero() {
           }}
         >
           <PRODUCTS.MESH.logo className={clsx('h-7 w-auto', isHive && 'fill-current')} />
-          GraphQL-Mesh
+          GraphQL Mesh
         </button>
       </div>
       <div className="flex gap-24">


### PR DESCRIPTION
On none of the product websites we stylize the name with a dash, so it feels out of place to me.

<img width="261" alt="image" src="https://github.com/user-attachments/assets/45b22f1c-e7d2-4119-b0fb-460406588087">
<img width="536" alt="image" src="https://github.com/user-attachments/assets/fab15f8d-1dbb-4abe-a424-e262738df546">
