### PR TITLE
docs: include back-to-top and react version in nextra v3 guide

### DIFF
--- a/website/pages/blog/nextra-3/index.mdx
+++ b/website/pages/blog/nextra-3/index.mdx
@@ -800,6 +800,8 @@ by default instead of the previously custom `css-variables` theme.
 
 Node.js 16 is EOL and no longer supported.
 
+### {'Ensure to use React.js >= 18'}
+
 ### {'Ensure to use Next.js >= 13'}
 
 ### CJS `next.config.js` {'is no longer supported'}
@@ -999,6 +1001,10 @@ export default {
 This was made to make the bundle smaller.
 
 ### `sidebar.toggleButton` is set to `true` by default{/* eslint-disable-line */}
+
+### `toc.backToTop` should use a JSX element or a React component{/* eslint-disable-line */}
+
+To disable it, you can set `toc.backToTop` to `null`.
 
 </Steps>
 

--- a/website/pages/blog/nextra-3/index.mdx
+++ b/website/pages/blog/nextra-3/index.mdx
@@ -3,6 +3,7 @@ title: Nextra 3 – Your Favourite MDX Framework, Now on 🧪 Steroids
 tags: [nextra, nextjs, react]
 authors: dimitri
 date: 2023-12-12
+updateDate: 2024-09-28
 description:
   MDX 3, new i18n, new _meta files with JSX support, more powerful TOC, remote MDX, better bundle
   size, MathJax, new code block styles, shikiji, ESM-only and more


### PR DESCRIPTION
## Description

Hi everyone, I'd like to add the `toc.backToTop` and the minimum React version changes to the Nextra v3 migration guide. Feel free to edit it directly or close this if it's unnecessary.