### PR TITLE
Do not include hive's sitemap

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -94,7 +94,7 @@ export const jsonConfig = {
     '/graphql/hive': {
       rewrite: 'hive-landing-page.pages.dev',
       crisp: { segments: ['hive-website'] },
-      sitemap: true,
+      sitemap: false,
     },
     '/graphql/gateway': {
       redirect: 'https://the-guild.dev/graphql/hive/docs/gateway',

--- a/packages/website-router/src/sitemap/transformer.ts
+++ b/packages/website-router/src/sitemap/transformer.ts
@@ -3,7 +3,11 @@ export class SitemapTransformer implements HTMLRewriterElementContentHandlers {
 
   element(element: Element) {
     element.append(
-      this.additionalUrls.map(url => `<sitemap><loc>${url}</loc></sitemap>`).join('\n'),
+      this.additionalUrls
+        // Hive has its own sitemap.xml and according to Google, it's better to separate it
+        .filter(url => !url.includes('/hive/'))
+        .map(url => `<sitemap><loc>${url}</loc></sitemap>`)
+        .join('\n'),
       { html: true },
     );
   }

--- a/packages/website-router/src/sitemap/transformer.ts
+++ b/packages/website-router/src/sitemap/transformer.ts
@@ -3,11 +3,7 @@ export class SitemapTransformer implements HTMLRewriterElementContentHandlers {
 
   element(element: Element) {
     element.append(
-      this.additionalUrls
-        // Hive has its own sitemap.xml and according to Google, it's better to separate it
-        .filter(url => !url.includes('/hive/'))
-        .map(url => `<sitemap><loc>${url}</loc></sitemap>`)
-        .join('\n'),
+      this.additionalUrls.map(url => `<sitemap><loc>${url}</loc></sitemap>`).join('\n'),
       { html: true },
     );
   }


### PR DESCRIPTION
 Hive has its own sitemap.xml and according to Google, it's better to separate it