### PR TITLE
Fix the href attributes of jump links

### DIFF
--- a/website/pages/blog/nextra-4/index.mdx
+++ b/website/pages/blog/nextra-4/index.mdx
@@ -611,7 +611,7 @@ included. This makes it easier to identify the broken page that led the user to 
 ### Migration Guide
 
 <Steps>
-<h4>Choose [MDX rendering mode](#new-2-rendering-modes)</h4>
+<h4>Choose [MDX rendering mode](#app-router-support)</h4>
 
 <h4>Add `layout.jsx` file</h4>
 
@@ -805,7 +805,7 @@ follow [search setup steps](#pagefind-setup).
 ### Migration Guide
 
 <Steps>
-<h4>Choose [MDX rendering mode](#new-2-rendering-modes)</h4>
+<h4>Choose [MDX rendering mode](#app-router-support)</h4>
 <h4>Migrate `theme.config` options</h4>
 <h4>Add `layout.jsx` file</h4>
 


### PR DESCRIPTION
## What

It's a small fix for the jump links in the Nextra v4 blog post, which weren't working correctly. Feel free to edit it directly or close this if it's unnecessary.