### PR TITLE
Redirect to federation benchmark pages project not workers

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -92,7 +92,7 @@ export const jsonConfig = {
       sitemap: false,
     },
     '/graphql/hive/federation-gateway-performance': {
-      rewrite: 'federation-gateway-benchmark.theguild.workers.dev',
+      rewrite: 'federation-gateway-benchmark.pages.dev',
       crisp: { segments: ['hive-website'] },
       sitemap: false,
     },


### PR DESCRIPTION
Point to the new pages project instead of worker;
Related https://github.com/graphql-hive/graphql-gateways-benchmark/pull/777