### PR TITLE
Remove em-dashes from the website copy

### DIFF
--- a/website-astro/src/components/ContactDialog.astro
+++ b/website-astro/src/components/ContactDialog.astro
@@ -27,7 +27,7 @@
         Talk to an engineer
       </h2>
       <p class="mb-6 text-sm text-[var(--muted)]">
-        Tell us a bit about your setup and what you're after — an engineer who maintains these tools
+        Tell us a bit about your setup and what you're after. An engineer who maintains these tools
         will get back to you.
       </p>
       <form data-contact-form novalidate>
@@ -74,7 +74,7 @@
           </label>
         </div>
         <p data-contact-error hidden class="mt-4 font-mono text-[13px] text-[var(--amber)]">
-          Something went wrong — please try again, or email us at <a
+          Something went wrong. Please try again, or email us at <a
             class="underline underline-offset-2 hover:text-[var(--strong)]"
             href="mailto:contact@the-guild.dev">contact@the-guild.dev</a
           >.
@@ -103,7 +103,7 @@
       <h2 class="mb-2 font-mono text-[22px] font-semibold tracking-[-.03em] text-[var(--green)]">
         Message sent
       </h2>
-      <p class="mb-6 text-sm text-[var(--muted)]">Thank you — we'll contact you soon.</p>
+      <p class="mb-6 text-sm text-[var(--muted)]">Thank you, we'll contact you soon.</p>
       <button
         type="button"
         data-contact-close

--- a/website-astro/src/pages/404.astro
+++ b/website-astro/src/pages/404.astro
@@ -7,7 +7,7 @@ import { guildMark } from '../components/product-logos';
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Page not found — The Guild" description="This page does not exist.">
+<Layout title="Page not found | The Guild" description="This page does not exist.">
   <main class="flex min-h-screen flex-col items-center justify-center px-6 text-center">
     <svg
       aria-hidden="true"
@@ -23,13 +23,13 @@ import Layout from '../layouts/Layout.astro';
     <h1
       class="mb-4 font-mono text-[clamp(28px,5vw,44px)] font-semibold tracking-[-.04em] text-[var(--strong)]"
     >
-      404 — page not found<span
+      404: page not found<span
         aria-hidden="true"
         class="ml-[.13em] inline-block h-[.82em] w-[.09em] animate-blink bg-[var(--green)] align-[-.04em] motion-reduce:animate-none"
       ></span>
     </h1>
     <p class="mb-8 max-w-[440px] text-[15px] text-[var(--muted)]">
-      The path you requested doesn't exist — it may have moved to the <a
+      The path you requested doesn't exist. It may have moved to the <a
         class="text-[var(--text)] underline decoration-[var(--line-strong)] underline-offset-2 hover:text-[var(--strong)] hover:decoration-current"
         href="https://the-guild.dev/graphql/hive">Hive site</a
       >.

--- a/website-astro/src/pages/blog/[...id].astro
+++ b/website-astro/src/pages/blog/[...id].astro
@@ -32,7 +32,7 @@ const formatDate = (date: Date) =>
 ---
 
 <Layout
-  title={`${post.data.title} — The Guild Blog`}
+  title={`${post.data.title} | The Guild Blog`}
   description={post.data.description}
   image={post.data.image}
   type="article"

--- a/website-astro/src/pages/blog/index.astro
+++ b/website-astro/src/pages/blog/index.astro
@@ -44,8 +44,8 @@ const formatDate = (date: Date) =>
 ---
 
 <Layout
-  title="Blog — The Guild"
-  description="Writing from The Guild — open source, GraphQL, and the craft of long-term software."
+  title="Blog | The Guild"
+  description="Writing from The Guild on open source, GraphQL, and the craft of long-term software."
 >
   <header
     class="sticky top-0 z-20 border-b border-[var(--line)] bg-[var(--nav-bg)] backdrop-blur-[10px]"

--- a/website-astro/src/pages/feed.xml.ts
+++ b/website-astro/src/pages/feed.xml.ts
@@ -34,7 +34,7 @@ export const GET: APIRoute = async ({ site }) => {
   <channel>
     <title>The Guild Blog</title>
     <link>${site}</link>
-    <description>Writing from The Guild — open source, GraphQL, and the craft of long-term software.</description>
+    <description>Writing from The Guild on open source, GraphQL, and the craft of long-term software.</description>
     <atom:link href="${new URL('/feed.xml', site).href}" rel="self" type="application/rss+xml"/>
 ${items
   .map(

--- a/website-astro/src/pages/index.astro
+++ b/website-astro/src/pages/index.astro
@@ -307,8 +307,8 @@ const stellateCaseStudies = [
           </h2>
           <div class="text-[var(--muted)] [&_strong]:text-[var(--text)]">
             Vendors show you roadmaps; we'd rather show you history. The pattern to notice: when
-            others left the ecosystem, <strong>we stayed and took over the maintenance</strong>, four
-            times now.
+            others left the ecosystem, <strong>we stayed and took over the maintenance</strong>,
+            four times now.
           </div>
         </div>
         <div class="border-l border-[var(--line-strong)]">
@@ -404,14 +404,15 @@ const stellateCaseStudies = [
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--hive)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Observability</b>: per-operation, per-client
-                usage analytics; know exactly who depends on every field before you touch it.
+                <b class="font-semibold text-[var(--text)]">Observability</b>: per-operation,
+                per-client usage analytics; know exactly who depends on every field before you touch
+                it.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--hive)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Enterprise controls</b>: SSO, RBAC, audit
-                logs, self-hosting, schema policies.
+                <b class="font-semibold text-[var(--text)]">Enterprise controls</b>: SSO, RBAC,
+                audit logs, self-hosting, schema policies.
               </li>
             </ul>
           </article>
@@ -444,26 +445,28 @@ const stellateCaseStudies = [
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Edge caching</b>: GraphQL-aware invalidation
-                at the CDN layer; serve reads from the edge, pass mutations through and invalidate precisely.
+                <b class="font-semibold text-[var(--text)]">Edge caching</b>: GraphQL-aware
+                invalidation at the CDN layer; serve reads from the edge, pass mutations through and
+                invalidate precisely.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Protection</b>: rate limiting, query-depth
-                and complexity limits, and persisted-operation enforcement at the perimeter.
+                <b class="font-semibold text-[var(--text)]">Protection</b>: rate limiting,
+                query-depth and complexity limits, and persisted-operation enforcement at the
+                perimeter.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Insight</b>: see cache hit rates and origin
-                load per operation, per client.
+                <b class="font-semibold text-[var(--text)]">Insight</b>: see cache hit rates and
+                origin load per operation, per client.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Independent</b>: works with Apollo, Yoga,
-                Hive, or any spec-compliant GraphQL server.
+                <b class="font-semibold text-[var(--text)]">Independent</b>: works with Apollo,
+                Yoga, Hive, or any spec-compliant GraphQL server.
               </li>
             </ul>
           </article>
@@ -738,9 +741,8 @@ const stellateCaseStudies = [
         </h2>
         <p class="mb-7 max-w-[700px] text-[var(--muted)]">
           Looking to work with The Guild, learn more about our products, or just validate your API
-          strategy with us? We'll be happy to speak with you and learn about your efforts, for
-          free. You'll be talking to the engineers who maintain the tools you already run, not an
-          SDR.
+          strategy with us? We'll be happy to speak with you and learn about your efforts, for free.
+          You'll be talking to the engineers who maintain the tools you already run, not an SDR.
         </p>
         <div class="flex flex-wrap gap-2.5">
           <CommandLink href="#contact" primary data-contact-open>talk to an engineer</CommandLink>

--- a/website-astro/src/pages/index.astro
+++ b/website-astro/src/pages/index.astro
@@ -17,7 +17,7 @@ const federationAuditHref = 'https://github.com/graphql-hive/federation-gateway-
 const history = [
   {
     year: '2015',
-    title: "GraphQL goes public — we're already in",
+    title: "GraphQL goes public, and we're already in",
     copy: "Building and contributing from the ecosystem's first year. Not tourists who arrived when it got popular.",
   },
   {
@@ -25,18 +25,18 @@ const history = [
     title: 'GraphQL Codegen ships',
     href: 'https://the-guild.dev/graphql/codegen',
     badge: 'maintained 10+ years',
-    copy: 'Type-safe GraphQL for millions of developers. A decade of continuous releases — the longest-maintained tool of its kind in the ecosystem.',
+    copy: 'Type-safe GraphQL for millions of developers. A decade of continuous releases, the longest-maintained tool of its kind in the ecosystem.',
   },
   {
     year: '2020',
-    title: 'GraphQL-Tools — adopted from Apollo',
+    title: 'GraphQL-Tools, adopted from Apollo',
     href: 'https://the-guild.dev/graphql/tools',
     badge: 'alive & growing',
     copy: 'When Apollo stepped back, we took over the most-depended-on schema library in GraphQL and kept every user shipping.',
   },
   {
     year: '2021',
-    title: 'GraphQL Yoga — adopted from Prisma',
+    title: 'GraphQL Yoga, adopted from Prisma',
     href: 'https://the-guild.dev/graphql/yoga-server',
     badge: 'alive & growing',
     copy: 'Prisma moved on; we rebuilt Yoga into the fully-featured, spec-compliant GraphQL server it is today.',
@@ -46,18 +46,18 @@ const history = [
     title: 'Launched Hive platform',
     href: 'https://the-guild.dev/graphql/hive/blog/announcing-graphql-hive-release',
     badge: 'flagship',
-    copy: 'The GraphQL federation platform — schema registry, observability, and gateway. MIT-licensed from day one, and fully self-hostable by the end of the year.',
+    copy: 'The GraphQL federation platform: schema registry, observability, and gateway. MIT-licensed from day one, and fully self-hostable by the end of the year.',
   },
   {
     year: '2024',
-    title: 'Stellate — acquired, product saved',
+    title: 'Stellate acquired, product saved',
     href: stellateAcquisitionHref,
     badge: 'alive & growing',
-    copy: 'The CDN for GraphQL joined The Guild — customers kept their edge, the product kept its roadmap.',
+    copy: 'The CDN for GraphQL joined The Guild. Customers kept their edge, the product kept its roadmap.',
   },
   {
     year: '2026',
-    title: 'Grafbase — acquired, users migrated',
+    title: 'Grafbase acquired, users migrated',
     href: grafbaseAcquisitionHref,
     badge: 'merged into Hive',
     copy: 'Second acquisition funded from profit, not funding.',
@@ -78,7 +78,7 @@ const caseStudies = [
   {
     company: 'Buffer',
     industry: 'Social media',
-    copy: 'Planning, publishing, and analytics across 10+ networks — on Hive.',
+    copy: 'Planning, publishing, and analytics across 10+ networks, all on Hive.',
     href: 'https://the-guild.dev/graphql/hive/case-studies/buffer',
   },
   {
@@ -142,7 +142,7 @@ const stellateCaseStudies = [
 ---
 
 <Layout
-  title="The Guild — GraphQL infrastructure for teams that ship"
+  title="The Guild: GraphQL infrastructure for teams that ship"
   description="Open-source GraphQL infrastructure for enterprises, built and maintained by The Guild."
 >
   <header
@@ -214,8 +214,8 @@ const stellateCaseStudies = [
           We build <a
             class="font-semibold text-[var(--hive)] hover:text-[var(--strong)]"
             href="https://the-guild.dev/graphql/hive">Hive</a
-          >, the open-source GraphQL Federation platform — schema registry, router, and
-          observability — and <a
+          >, the open-source GraphQL Federation platform (schema registry, router, and
+          observability), and <a
             class="font-semibold text-[var(--stellate)] hover:text-[var(--strong)]"
             href="https://stellate.co">Stellate</a
           >, the CDN and cache for GraphQL. <a
@@ -245,7 +245,7 @@ const stellateCaseStudies = [
       <div class="mx-auto w-[calc(100%-24px)] max-w-shell sm:w-[calc(100%-40px)]">
         <SectionHeader
           path="~/the-guild/why"
-          title="Built for trust, structured for the long term — and you can verify all of it."
+          title="Built for trust, structured for the long term. And you can verify all of it."
         >
           Most infrastructure vendors ask you to trust their intentions. We've structured the whole
           company from the beginning so you don't have to: the license, the finances, and the track
@@ -272,17 +272,17 @@ const stellateCaseStudies = [
               > and <a
                 class="text-[var(--text)] underline decoration-[var(--line-strong)] underline-offset-2 hover:text-[var(--strong)] hover:decoration-current"
                 href={grafbaseAcquisitionHref}>Grafbase (2026)</a
-              > from cash flow — not from a raise.
+              > from cash flow, not from a raise.
             </p></Cell
           >
           <Cell
-            title="Adopt one piece — or the whole platform"
+            title="Adopt one piece, or the whole platform"
             evidence="learn more ↗"
             evidenceHref="https://the-guild.dev/graphql/hive/docs/other-integrations/apollo-router"
             ><p>
               The opposite of lock-in: <b>Hive Console</b> and <b>Hive Router</b> each work standalone.
               Run just the schema registry with the gateway you already have, or just the router with
-              your existing registry — and migrate the rest gradually, only what you want, when you want.
+              your existing registry, then migrate the rest gradually, only what you want, when you want.
             </p></Cell
           >
         </div>
@@ -307,7 +307,7 @@ const stellateCaseStudies = [
           </h2>
           <div class="text-[var(--muted)] [&_strong]:text-[var(--text)]">
             Vendors show you roadmaps; we'd rather show you history. The pattern to notice: when
-            others left the ecosystem, <strong>we stayed and took over the maintenance</strong> — four
+            others left the ecosystem, <strong>we stayed and took over the maintenance</strong>, four
             times now.
           </div>
         </div>
@@ -351,8 +351,8 @@ const stellateCaseStudies = [
           path="~/the-guild/platform"
           title="Hive runs your federation. Stellate makes it fast everywhere."
         >
-          One open-source platform for the whole GraphQL lifecycle — schema registry, gateway, and
-          observability — with a global edge in front of it. Adopt each piece independently; they're
+          One open-source platform for the whole GraphQL lifecycle (schema registry, gateway, and
+          observability), with a global edge in front of it. Adopt each piece independently; they're
           better together.
         </SectionHeader>
         <div class="grid grid-cols-1 gap-16 lg:grid-cols-2">
@@ -383,7 +383,7 @@ const stellateCaseStudies = [
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--hive)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Schema registry</b> — composition checks
+                <b class="font-semibold text-[var(--text)]">Schema registry</b>: composition checks
                 against live traffic and persisted operations, so a breaking change is caught in CI,
                 not by a customer.
               </li>
@@ -393,7 +393,7 @@ const stellateCaseStudies = [
                 <a
                   class="font-mono font-semibold text-[var(--text)] hover:underline"
                   href="https://github.com/graphql-hive/router">Hive Router</a
-                > — open-source (MIT) federation router built in Rust; the fastest gateway in <a
+                >: open-source (MIT) federation router built in Rust; the fastest gateway in <a
                   class="text-[var(--text)] underline decoration-[var(--line-strong)] underline-offset-2 hover:text-[var(--strong)] hover:decoration-current"
                   href={benchmarksHref}>public benchmarks</a
                 >, verified by a <a
@@ -404,13 +404,13 @@ const stellateCaseStudies = [
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--hive)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Observability</b> — per-operation, per-client
+                <b class="font-semibold text-[var(--text)]">Observability</b>: per-operation, per-client
                 usage analytics; know exactly who depends on every field before you touch it.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--hive)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Enterprise controls</b> — SSO, RBAC, audit
+                <b class="font-semibold text-[var(--text)]">Enterprise controls</b>: SSO, RBAC, audit
                 logs, self-hosting, schema policies.
               </li>
             </ul>
@@ -434,7 +434,7 @@ const stellateCaseStudies = [
             </a>
             <div class="mb-5 font-mono text-[12px] text-[var(--muted)]">the CDN for GraphQL</div>
             <p class="text-[var(--muted)]">
-              GraphQL-aware edge caching and protection, in front of any GraphQL API — including the
+              GraphQL-aware edge caching and protection, in front of any GraphQL API, including the
               ones Hive doesn't run. <a
                 class="text-[var(--text)] underline decoration-[var(--line-strong)] underline-offset-2 hover:text-[var(--strong)] hover:decoration-current"
                 href={stellateAcquisitionHref}>Acquired by The Guild in 2024</a
@@ -444,25 +444,25 @@ const stellateCaseStudies = [
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Edge caching</b> — GraphQL-aware invalidation
+                <b class="font-semibold text-[var(--text)]">Edge caching</b>: GraphQL-aware invalidation
                 at the CDN layer; serve reads from the edge, pass mutations through and invalidate precisely.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Protection</b> — rate limiting, query-depth
+                <b class="font-semibold text-[var(--text)]">Protection</b>: rate limiting, query-depth
                 and complexity limits, and persisted-operation enforcement at the perimeter.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Insight</b> — see cache hit rates and origin
+                <b class="font-semibold text-[var(--text)]">Insight</b>: see cache hit rates and origin
                 load per operation, per client.
               </li>
               <li
                 class="relative border-t border-dotted border-[var(--line-strong)] py-2.5 pl-[22px] text-[15px] text-[var(--muted)] before:absolute before:left-0 before:text-[var(--stellate)] before:content-['--']"
               >
-                <b class="font-semibold text-[var(--text)]">Independent</b> — works with Apollo, Yoga,
+                <b class="font-semibold text-[var(--text)]">Independent</b>: works with Apollo, Yoga,
                 Hive, or any spec-compliant GraphQL server.
               </li>
             </ul>
@@ -499,20 +499,20 @@ const stellateCaseStudies = [
     >
       <div class="mx-auto w-[calc(100%-24px)] max-w-shell sm:w-[calc(100%-40px)]">
         <SectionHeader path="~/the-guild/proof" title="In production, at scale, on the record.">
-          Public case studies with named companies — not anonymized "a leading enterprise" slides.
+          Public case studies with named companies, not anonymized "a leading enterprise" slides.
         </SectionHeader>
         <div class="grid grid-cols-1 gap-16 lg:grid-cols-2">
           <blockquote
             class="border-t border-[var(--line)] pt-5 transition-colors hover:border-[var(--line-strong)]"
           >
             <p class="mb-[18px] font-mono text-[17px] leading-[1.55]">
-              Hemnet moved from Apollo Router to Hive Gateway expecting a performance cost — and
+              Hemnet moved from Apollo Router to Hive Gateway expecting a performance cost, and
               measured it running at <b class="text-[var(--amber)]"
                 >less than 30% of Apollo Router's resource usage</b
               >.
             </p>
             <footer class="text-xs text-[var(--muted)]">
-              Hemnet — Sweden's largest property platform
+              Hemnet, Sweden's largest property platform
             </footer>
           </blockquote>
           <blockquote
@@ -520,10 +520,10 @@ const stellateCaseStudies = [
           >
             <p class="mb-[18px] font-mono text-[17px] leading-[1.55]">
               "Hive empowers us to <b class="text-[var(--amber)]">confidently evolve our schemas</b>
-              — ensuring seamless API updates, detecting potential breaking changes, and guiding developers."
+              by ensuring seamless API updates, detecting potential breaking changes, and guiding developers."
             </p>
             <footer class="text-xs text-[var(--muted)]">
-              Wealthsimple — one of Canada's fastest-growing financial institutions
+              Wealthsimple, one of Canada's fastest-growing financial institutions
             </footer>
           </blockquote>
         </div>
@@ -651,7 +651,7 @@ const stellateCaseStudies = [
       <div class="mx-auto w-[calc(100%-24px)] max-w-shell sm:w-[calc(100%-40px)]">
         <SectionHeader path="~/the-guild/security" title="Your security review, pre-answered.">
           For procurement and security reviewers: the attestations, controls, and deployment options
-          you'll ask about — each with a public source you can check before the first call.
+          you'll ask about, each with a public source you can check before the first call.
         </SectionHeader>
         <div class="grid grid-cols-1 gap-x-8 gap-y-10 md:grid-cols-2 lg:grid-cols-3">
           <Cell
@@ -665,7 +665,7 @@ const stellateCaseStudies = [
               SOC 2 Type II
             </div><p>
               <b>SOC 2 Type II</b> attested and listed in the <b>Cloud Security Alliance STAR</b>
-              registry. Reports, policies, and subprocessors are published in the trust center — no NDA
+              registry. Reports, policies, and subprocessors are published in the trust center, no NDA
               required to read them.
             </p></Cell
           >
@@ -679,7 +679,7 @@ const stellateCaseStudies = [
             >
               air-gap
             </div><p>
-              Use the managed cloud, or run the entire platform on your own infrastructure — in your
+              Use the managed cloud, or run the entire platform on your own infrastructure, in your
               VPC or fully <b>air-gapped</b>. Same MIT-licensed code either way, not a stripped
               "enterprise edition."
             </p></Cell
@@ -702,7 +702,7 @@ const stellateCaseStudies = [
                 class="text-[var(--text)] underline decoration-[var(--line-strong)] underline-offset-2 hover:text-[var(--strong)] hover:decoration-current"
                 href="https://the-guild.dev/graphql/hive/docs/schema-registry/management/audit-logs"
                 >audit logs</a
-              > — the controls your review checklist actually names.
+              >. The controls your review checklist actually names.
             </p></Cell
           >
         </div>
@@ -716,7 +716,7 @@ const stellateCaseStudies = [
       <div class="mx-auto w-[calc(100%-24px)] max-w-shell sm:w-[calc(100%-40px)]">
         <div class="max-w-[900px] font-mono text-[var(--muted)] [&_strong]:text-[var(--text)]">
           <strong>Also: AI agents, when you're ready.</strong> The same supergraph that governs your
-          GraphQL consumers extends to agents — skills declared in the schema, exposed over MCP, governed
+          GraphQL consumers extends to agents: skills declared in the schema, exposed over MCP, governed
           by the same checks. No new platform, no replatforming. It's there when you want it, and invisible
           until you do. <a
             class="text-[var(--green)] transition-colors hover:text-[var(--strong)]"
@@ -738,7 +738,7 @@ const stellateCaseStudies = [
         </h2>
         <p class="mb-7 max-w-[700px] text-[var(--muted)]">
           Looking to work with The Guild, learn more about our products, or just validate your API
-          strategy with us? We'll be happy to speak with you and learn about your efforts — for
+          strategy with us? We'll be happy to speak with you and learn about your efforts, for
           free. You'll be talking to the engineers who maintain the tools you already run, not an
           SDR.
         </p>


### PR DESCRIPTION
People flagged the em-dashes as making the copy read AI-written. Every em-dash in the site copy is rewritten case by case:

- Definition-style lead-ins (feature bullets, timeline entries) use colons or commas
- Dash-spliced sentences become two sentences or comma clauses; parenthetical asides use parentheses
- Page titles switch to conventional separators (`The Guild: …`, `… | The Guild Blog`)
- The Wealthsimple pull-quote returns to its original wording ("by ensuring…"), which a trim had dashed

Untouched on purpose: blog article content (human-authored posts), code comments, and the `·` / `→` design glyphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)