### PR TITLE
Add Strict-Transport-Security header to router responses

### DIFF
--- a/packages/website-router/src/index.ts
+++ b/packages/website-router/src/index.ts
@@ -48,6 +48,10 @@ const manipulateResponse: ManipulateResponseFn = async (record, rawResponse) => 
   // Modify response and add client side caching headers
   result = new Response(result.body, result);
   result.headers.append('Cache-Control', `s-maxage=${clientToWorkerMaxAge}`);
+  // Everything is served over HTTPS behind Cloudflare; instruct browsers to
+  // never downgrade. Scoped to this hostname only (no includeSubDomains) so
+  // unrelated subdomains are unaffected.
+  result.headers.set('Strict-Transport-Security', 'max-age=31536000');
 
   return result;
 };


### PR DESCRIPTION
## What

Adds `Strict-Transport-Security: max-age=31536000` to every response the router serves.

## Why

the-guild.dev responses currently carry no HSTS header (surfaced during the Hive docs cutover production review), so a user's first plain-HTTP request can be intercepted before the HTTPS redirect. All traffic is already HTTPS behind Cloudflare — this just tells browsers to never downgrade.

Deliberately conservative: hostname-scoped (no `includeSubDomains`, so unrelated the-guild.dev subdomains are unaffected) and no `preload`. Set in `manipulateResponse` next to the existing `Cache-Control` append, so it applies to HTML and passthrough responses alike.

(The other router follow-up from the review — removing the temporary `/graphql/hive_astro` route — was already done in 4cfcdaeb.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)