### PR TITLE
Fix iOS contact-form zoom and unify small-label casing

### DIFF
--- a/website-astro/src/components/ContactDialog.astro
+++ b/website-astro/src/components/ContactDialog.astro
@@ -42,7 +42,7 @@
               type="text"
               required
               autocomplete="name"
-              class="w-full border border-[var(--line-strong)] bg-transparent px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--faint)] focus:outline focus:outline-1 focus:outline-offset-2 focus:outline-[var(--green)]"
+              class="w-full border border-[var(--line-strong)] bg-transparent px-3 py-2 text-[16px] text-[var(--text)] placeholder:text-[var(--faint)] focus:outline focus:outline-1 focus:outline-offset-2 focus:outline-[var(--green)]"
               placeholder="Ada Lovelace"
             />
           </label>
@@ -56,7 +56,7 @@
               type="email"
               required
               autocomplete="email"
-              class="w-full border border-[var(--line-strong)] bg-transparent px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--faint)] focus:outline focus:outline-1 focus:outline-offset-2 focus:outline-[var(--green)]"
+              class="w-full border border-[var(--line-strong)] bg-transparent px-3 py-2 text-[16px] text-[var(--text)] placeholder:text-[var(--faint)] focus:outline focus:outline-1 focus:outline-offset-2 focus:outline-[var(--green)]"
               placeholder="you@company.com"
             />
           </label>
@@ -69,7 +69,7 @@
               name="notes"
               required
               rows="4"
-              class="w-full resize-y border border-[var(--line-strong)] bg-transparent px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--faint)] focus:outline focus:outline-1 focus:outline-offset-2 focus:outline-[var(--green)]"
+              class="w-full resize-y border border-[var(--line-strong)] bg-transparent px-3 py-2 text-[16px] text-[var(--text)] placeholder:text-[var(--faint)] focus:outline focus:outline-1 focus:outline-offset-2 focus:outline-[var(--green)]"
               placeholder="What are you building, and how can we help?"></textarea>
           </label>
         </div>

--- a/website-astro/src/layouts/Layout.astro
+++ b/website-astro/src/layouts/Layout.astro
@@ -24,7 +24,7 @@ const imageUrl = image ? new URL(image, Astro.site).href : undefined;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
     <link rel="icon" href="/static/favicon.ico" sizes="any" />
     <link rel="icon" href="/static/favicon-dark.ico" media="(prefers-color-scheme: dark)" />

--- a/website-astro/src/pages/index.astro
+++ b/website-astro/src/pages/index.astro
@@ -473,7 +473,7 @@ const stellateCaseStudies = [
         </div>
         <div class="mt-12 border-t border-[var(--line)] pt-7">
           <div class="mb-5 font-mono text-[12px] tracking-[.075em] text-[var(--muted)]">
-            Also part of our GraphQL ecosystem:
+            also part of our graphql ecosystem:
           </div>
           <div
             class="flex gap-9 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
@@ -564,7 +564,7 @@ const stellateCaseStudies = [
                     )}
                     {study.company}
                   </div>
-                  <div class="mb-3 mt-1 font-mono text-[11px] uppercase text-[var(--faint)]">
+                  <div class="mb-3 mt-1 font-mono text-[11px] lowercase text-[var(--faint)]">
                     {study.industry}
                   </div>
                   <p class="text-[15px] text-[var(--muted)]">
@@ -584,7 +584,7 @@ const stellateCaseStudies = [
             class="group mt-8 inline-flex items-center gap-1.5 font-mono text-[12px] text-[var(--green)] transition-colors after:text-[var(--faint)] after:transition-transform after:content-['→'] hover:text-[var(--strong)] hover:after:translate-x-0.5 hover:after:text-current"
             href="https://the-guild.dev/graphql/hive/case-studies"
           >
-            Read more Hive case studies
+            read more hive case studies
           </a>
         </div>
         <div class="mt-12 border-t border-[var(--line)] pt-7">
@@ -621,7 +621,7 @@ const stellateCaseStudies = [
                     )}
                     {study.company}
                   </div>
-                  <div class="mb-3 mt-1 font-mono text-[11px] uppercase text-[var(--faint)]">
+                  <div class="mb-3 mt-1 font-mono text-[11px] lowercase text-[var(--faint)]">
                     {study.industry}
                   </div>
                   <p class="text-[15px] text-[var(--muted)]">
@@ -641,7 +641,7 @@ const stellateCaseStudies = [
             class="group mt-8 inline-flex items-center gap-1.5 font-mono text-[12px] text-[var(--green)] transition-colors after:text-[var(--faint)] after:transition-transform after:content-['→'] hover:text-[var(--strong)] hover:after:translate-x-0.5 hover:after:text-current"
             href="https://stellate.co/use-cases/industry/ecommerce"
           >
-            Read more Stellate case studies
+            read more stellate case studies
           </a>
         </div>
       </div>


### PR DESCRIPTION
Fixes the mobile feedback from the Slack thread:

**Contact modal zoom / horizontal scroll on iOS** — iOS Safari auto-zooms when a focused input's font-size is below 16px, and the page stays zoomed (with horizontal scroll) after closing the dialog. The form inputs and textarea now use 16px, and the viewport meta gains `initial-scale=1`.

**Lowercase/title-case mix** — the small mono UI labels now follow the terminal style consistently: industry tags on case-study cards (`social media`, `e-commerce`, …), the `read more hive/stellate case studies` links, and the `also part of our graphql ecosystem:` strip label are all lowercase, matching the nav, command links, and badges. Headings, prose, and brand names keep their casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)