### PR TITLE
Open the contact dialog at the top of the page for /contact

### DIFF
--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,3 +1,3 @@
 # Main-site redirects. The Hive rules are appended after this block at build
 # time by scripts/hive/generate-redirects.ts.
-/contact /#contact 301
+/contact /#talk-to-an-engineer 301

--- a/website/src/components/ContactDialog.astro
+++ b/website/src/components/ContactDialog.astro
@@ -139,10 +139,11 @@
     });
   }
 
-  // /contact 301s to /#contact (see public/_redirects) — arriving with the
-  // hash opens the dialog over the contact section. In-page openers call
-  // preventDefault, so this only fires for external entrances.
-  if (location.hash === '#contact') {
+  // /contact 301s to /#talk-to-an-engineer (see public/_redirects). The
+  // hash matches no element on purpose: the page stays at the top and only
+  // the dialog opens. In-page openers call preventDefault, so this only
+  // fires for external entrances.
+  if (location.hash === '#talk-to-an-engineer') {
     openDialog();
   }
 


### PR DESCRIPTION
Follow-up to the `/contact` redirect: it targeted `/#contact`, which is the contact *section's* element id — the browser scrolled down to it before the dialog opened. The redirect now targets `/#talk-to-an-engineer`, a hash that matches no element: the page stays at the top and the "talk to an engineer" dialog opens over the hero.

Browser-verified on the built site: loading `/#talk-to-an-engineer` gives `dialog open, scrollY 0`; `/#contact` keeps behaving as a plain section anchor for anyone who bookmarked it.

Note: the homepage HTML is cached at the edge, so the new dialog-opening behavior applies once the cached page rolls over after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `/contact` link to open the “Talk to an Engineer” section.
  * Preserved the existing behavior for opening the contact dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->