### PR TITLE
Rescue browsers that cached the first /contact redirect

### DIFF
--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,3 +1,3 @@
 # Main-site redirects. The Hive rules are appended after this block at build
 # time by scripts/hive/generate-redirects.ts.
-/contact /#talk-to-an-engineer 301
+/contact /#talk-to-an-engineer 302

--- a/website/src/components/ContactDialog.astro
+++ b/website/src/components/ContactDialog.astro
@@ -139,12 +139,17 @@
     });
   }
 
-  // /contact 301s to /#talk-to-an-engineer (see public/_redirects). The
-  // hash matches no element on purpose: the page stays at the top and only
-  // the dialog opens. In-page openers call preventDefault, so this only
-  // fires for external entrances.
-  if (location.hash === '#talk-to-an-engineer') {
+  // /contact redirects to /#talk-to-an-engineer (see public/_redirects),
+  // which matches no element so the page stays at the top with the dialog
+  // open. #contact is handled the same way: browsers permanently cached the
+  // first deploy's 301 to it, and it is the contact section's id — so the
+  // anchor scroll is undone and the hash cleaned. In-page openers call
+  // preventDefault, so none of this fires for in-page clicks.
+  if (location.hash === '#talk-to-an-engineer' || location.hash === '#contact') {
+    history.replaceState(null, '', location.pathname + location.search);
     openDialog();
+    window.scrollTo(0, 0);
+    requestAnimationFrame(() => window.scrollTo(0, 0));
   }
 
   for (const closer of dialog.querySelectorAll('[data-contact-close]')) {


### PR DESCRIPTION
The Hive contact buttons correctly link to `https://the-guild.dev/contact`, and production serves the current redirect to `/#talk-to-an-engineer` — but browsers cache 301s permanently, so anyone who visited `/contact` while it still pointed at `/#contact` replays the old redirect locally: the browser scrolls to the contact section (bottom of the page) and no dialog opens.

Two changes:
- The dialog script now treats `#contact` the same as `#talk-to-an-engineer`: clean the hash from the URL, force scroll back to the top (after the browser's anchor scroll), and open the dialog. This rescues every cache-stuck browser and gives old `/#contact` links the intended UX.
- The redirect becomes a **302** so its target can change again without getting stuck in caches.

Browser-verified on the built site: both hashes land with `dialog open, scrollY 0, hash cleaned`; a plain `/` load stays closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The contact dialog now opens when visiting URLs with either `#contact` or `#talk-to-an-engineer`.
  - Opening the dialog from these links removes the hash and positions the page at the top.

- **Bug Fixes**
  - Updated the contact page redirect to preserve the referring URL temporarily, improving compatibility with contact-link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->