### PR TITLE
Fix the mechanical SEO defects from the search audit

### DIFF
--- a/packages/website-router/src/index.ts
+++ b/packages/website-router/src/index.ts
@@ -9,7 +9,7 @@ import { BannerHandler } from './html-handlers/banner';
 import { CrispHandler } from './html-handlers/crisp';
 import { GoogleAnalyticsHandler } from './html-handlers/ga';
 import { handleRobotsTxt, shouldHandleRobotsTxt } from './robots/handler';
-import { handleRewrite, ManipulateResponseFn, redirect } from './routing';
+import { handleRewrite, isLeakedRouteTemplate, ManipulateResponseFn, redirect } from './routing';
 import { handleSitemap, shouldHandleSitemap } from './sitemap/handler';
 
 const {
@@ -53,6 +53,14 @@ const manipulateResponse: ManipulateResponseFn = async (record, rawResponse) => 
 
 async function handleEvent(request: Request, sentry: Toucan): Promise<Response> {
   const parsedUrl = new URL(request.url);
+
+  // Old build bugs leaked route templates into public URLs; Google recrawls
+  // ~250 of them (SEO audit, SEO-03). 410 tells it they are gone for good -
+  // Pages _redirects cannot emit 410.
+  if (isLeakedRouteTemplate(parsedUrl.pathname)) {
+    return new Response('Gone', { status: 410 });
+  }
+
   sentry.addBreadcrumb({
     type: 'debug',
     data: {

--- a/packages/website-router/src/routing.test.ts
+++ b/packages/website-router/src/routing.test.ts
@@ -2,7 +2,7 @@
 
 import { equal } from 'node:assert/strict';
 import { test } from 'node:test';
-import { buildUpstreamUrl } from './routing';
+import { buildUpstreamUrl, isLeakedRouteTemplate } from './routing';
 
 test('preserveSearch keeps the original query string', () => {
   const upstreamUrl = buildUpstreamUrl({
@@ -34,4 +34,13 @@ test('default rewrite behavior still drops search params', () => {
   });
 
   equal(upstreamUrl.toString(), 'https://hive-platform-docs.theguild.workers.dev/_serverFn/test');
+});
+
+test('leaked route templates are recognised', () => {
+  equal(isLeakedRouteTemplate('/_landing/blog/$/blog/some-post'), true);
+  equal(isLeakedRouteTemplate('/docs/$/docs/gateway'), true);
+  equal(isLeakedRouteTemplate('/blog/$'), true);
+  equal(isLeakedRouteTemplate('/graphql/hive/docs/gateway'), false);
+  equal(isLeakedRouteTemplate('/blog/price-of-graphql'), false);
+  equal(isLeakedRouteTemplate('/'), false);
 });

--- a/packages/website-router/src/routing.ts
+++ b/packages/website-router/src/routing.ts
@@ -228,3 +228,11 @@ export async function handleRewrite(options: {
 
   return response;
 }
+
+/**
+ * Old build bugs leaked route templates into public URLs (/_landing/...,
+ * literal $-segments). Google still recrawls them; they deserve a 410.
+ */
+export function isLeakedRouteTemplate(pathname: string) {
+  return pathname.includes('/_landing/') || /(^|\/)\$(\/|$)/.test(pathname);
+}

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
     "check": "astro check",
     "check-seo": "node scripts/hive/check-seo.ts",
     "dev": "astro dev",
-    "postbuild:hive": "node scripts/hive/generate-sitemap.ts && node scripts/hive/generate-redirects.ts && node scripts/hive/generate-headers.ts && pagefind --site dist/graphql/hive && node scripts/hive/verify-base-path.ts",
+    "postbuild:hive": "node scripts/hive/generate-sitemap.ts && node scripts/hive/generate-redirects.ts && node scripts/hive/generate-headers.ts && pagefind --site dist/graphql/hive && node scripts/hive/verify-base-path.ts && node scripts/verify-sitemaps.mjs",
     "postinstall": "playwright install chromium",
     "preview": "astro preview",
     "test": "vitest run src"

--- a/website/scripts/hive/generate-redirects.ts
+++ b/website/scripts/hive/generate-redirects.ts
@@ -1,3 +1,4 @@
+import { globSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
@@ -30,7 +31,43 @@ const astroOnlyRedirects = [
   },
 ];
 
+/**
+ * Old Guild-blog posts that migrated into the Hive blog kept their slugs; the
+ * root URLs 404'd for over a year, splitting backlink equity (SEO audit,
+ * SEO-02). Derived from the built output so new Hive posts are covered
+ * automatically and posts that exist on the root blog are never shadowed.
+ */
+const rootBlogSlugs = new Set(
+  globSync("blog/*.html", { cwd: outputDirectory }).map((file) =>
+    file.replace(/^blog\//, "").replace(/\.html$/, ""),
+  ),
+);
+const migratedBlogRedirects = globSync("graphql/hive/blog/*.html", {
+  cwd: outputDirectory,
+})
+  .map((file) => file.replace(/^graphql\/hive\/blog\//, "").replace(/\.html$/, ""))
+  .filter((slug) => slug !== "feed.xml" && !rootBlogSlugs.has(slug))
+  .map((slug) => ({
+    source: `/blog/${slug}`,
+    destination: `${PREFIX}/blog/${slug}`,
+    status: 301,
+  }));
+
+/**
+ * Dead-URL families Google still recrawls (SEO audit, SEO-03): pages that
+ * shipped without the base path from earlier build bugs. The route-template
+ * leaks (/_landing/..., $-segments) get 410s from the router worker instead —
+ * Pages _redirects cannot emit 410.
+ */
+const deadFamilyRedirects = [
+  { source: "/docs/*", destination: `${PREFIX}/docs/:splat`, status: 301 },
+  { source: "/product-updates/*", destination: `${PREFIX}/product-updates/:splat`, status: 301 },
+  { source: "/case-studies/*", destination: `${PREFIX}/case-studies/:splat`, status: 301 },
+];
+
 const redirects = [
+  ...migratedBlogRedirects,
+  ...deadFamilyRedirects,
   ...Object.entries(routeRules).map(([source, rule]) => {
     if (!rule.redirect || typeof rule.redirect === "string") {
       throw new Error(`Expected ${source} to contain a redirect object`);

--- a/website/scripts/hive/verify-base-path.ts
+++ b/website/scripts/hive/verify-base-path.ts
@@ -54,9 +54,10 @@ for (const file of globSync("**/*.html", { cwd: hiveDistDirectory })) {
   }
 }
 
-// Hive rules in the root-level _redirects must carry the mount prefix — an
-// un-prefixed source or destination would act on the main site instead.
-// Rules from the main site's own website/public/_redirects are exempt.
+// Redirect destinations that point into Hive content must carry the mount
+// prefix — an un-prefixed one would 404. Sources are legitimately
+// un-prefixed (legacy URLs redirecting INTO Hive); main-site rules from
+// website/public/_redirects are exempt entirely.
 const mainSiteRedirects = new Set(
   (existsSync(`${projectDirectory}/public/_redirects`)
     ? readFileSync(`${projectDirectory}/public/_redirects`, "utf8").split("\n")
@@ -67,10 +68,13 @@ if (existsSync(`${distDirectory}/_redirects`)) {
   for (const line of readFileSync(`${distDirectory}/_redirects`, "utf8").split("\n")) {
     if (!line.trim() || line.startsWith("#")) continue;
     if (mainSiteRedirects.has(line.trim())) continue;
-    for (const path of line.trim().split(/\s+/).slice(0, 2)) {
-      if (path.startsWith("/") && path !== base && !path.startsWith(`${base}/`)) {
-        report("_redirects", path);
-      }
+    const destination = line.trim().split(/\s+/)[1];
+    if (
+      destination?.startsWith("/") &&
+      destination !== base &&
+      !destination.startsWith(`${base}/`)
+    ) {
+      report("_redirects", destination);
     }
   }
 }

--- a/website/scripts/verify-sitemaps.mjs
+++ b/website/scripts/verify-sitemaps.mjs
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+/**
+ * Fails the build if any <loc> in the generated sitemaps does not correspond
+ * to a file in dist — the exact defect class from the SEO audit (SEO-01),
+ * where the Hive sitemap shipped 15 URLs that 404'd in production, pricing
+ * included.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const SITE = 'https://the-guild.dev';
+const dist = fileURLToPath(new URL('../dist', import.meta.url));
+
+/** Maps a public path to the dist file that serves it (build.format: 'file'). */
+function distCandidates(pathname) {
+  if (pathname === '/' || pathname === '') return [`${dist}/index.html`];
+  const decoded = decodeURI(pathname);
+  return [`${dist}${decoded}.html`, `${dist}${decoded}/index.html`, `${dist}${decoded}`];
+}
+
+const failures = [];
+let checked = 0;
+
+for (const sitemap of ['/sitemap-0.xml', '/graphql/hive/sitemap.xml']) {
+  const file = `${dist}${sitemap}`;
+  if (!existsSync(file)) {
+    failures.push(`${sitemap}: sitemap file missing from dist`);
+    continue;
+  }
+  const xml = readFileSync(file, 'utf8');
+  for (const [, loc] of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    checked++;
+    if (!loc.startsWith(SITE)) {
+      failures.push(`${sitemap}: <loc> outside the site: ${loc}`);
+      continue;
+    }
+    const pathname = loc.slice(SITE.length);
+    if (!distCandidates(pathname).some(candidate => existsSync(candidate))) {
+      failures.push(`${sitemap}: no dist file serves ${pathname || '/'}`);
+    }
+  }
+}
+
+// The index must reference both children.
+const index = readFileSync(`${dist}/sitemap.xml`, 'utf8');
+for (const child of [`${SITE}/sitemap-0.xml`, `${SITE}/graphql/hive/sitemap.xml`]) {
+  if (!index.includes(`<loc>${child}</loc>`)) {
+    failures.push(`sitemap.xml index does not reference ${child}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`Sitemap verification failed (${failures.length} problems):`);
+  for (const failure of failures.slice(0, 25)) console.error(`  ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Sitemaps verified: ${checked} URLs all resolve to built files`);

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -9,9 +9,12 @@ interface Props {
   /** og:type — 'article' for blog posts, defaults to 'website' */
   type?: 'website' | 'article';
   publishedTime?: Date;
+  /** Error pages must not canonicalise themselves (a 404 with a canonical
+   * tells crawlers /404 is the canonical home of every dead URL). */
+  noCanonical?: boolean;
 }
 
-const { title, description, image, type = 'website', publishedTime } = Astro.props;
+const { title, description, image, type = 'website', publishedTime, noCanonical } = Astro.props;
 
 // With `build.format: 'file'`, pathnames carry the emitted .html suffix —
 // strip it so canonical URLs match the slashless public URLs.
@@ -31,13 +34,13 @@ const imageUrl = image ? new URL(image, Astro.site).href : undefined;
     <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png" />
     <link rel="apple-touch-icon" href="/static/apple-touch-icon.png" />
-    <link rel="canonical" href={canonical.href} />
+    {!noCanonical && <link rel="canonical" href={canonical.href} />}
     <link rel="alternate" type="application/rss+xml" title="The Guild Blog" href="/feed.xml" />
     <title>{title}</title>
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content={type} />
-    <meta property="og:url" content={canonical.href} />
+    {!noCanonical && <meta property="og:url" content={canonical.href} />}
     <meta property="og:site_name" content="The Guild" />
     {imageUrl && <meta property="og:image" content={imageUrl} />}
     {
@@ -49,6 +52,7 @@ const imageUrl = image ? new URL(image, Astro.site).href : undefined;
     <meta name="twitter:site" content="@TheGuildDev" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
+    <slot name="head" />
     <script is:inline>
       try {
         const saved = localStorage.getItem('guild-theme');

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -7,7 +7,7 @@ import { guildMark } from '../components/product-logos';
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Page not found | The Guild" description="This page does not exist.">
+<Layout title="Page not found | The Guild" description="This page does not exist." noCanonical>
   <main class="flex min-h-screen flex-col items-center justify-center px-6 text-center">
     <svg
       aria-hidden="true"

--- a/website/src/pages/graphql/hive/index.astro
+++ b/website/src/pages/graphql/hive/index.astro
@@ -26,6 +26,21 @@ const appUrl = "https://app.graphql-hive.com";
       description="Fully Open-Source schema registry, analytics and gateway for GraphQL federation and other GraphQL APIs"
       title="Open-Source GraphQL Federation Platform"
     />
+    <script
+      is:inline
+      type="application/ld+json"
+      set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: "Hive",
+        alternateName: "GraphQL Hive",
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Web",
+        url: "https://the-guild.dev/graphql/hive",
+        offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+        publisher: { "@type": "Organization", name: "The Guild", url: "https://the-guild.dev/" },
+      })}
+    />
   </head>
   <body class="text-green-1000 bg-white font-sans [color-scheme:light]">
     <SiteNavigation />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -9,6 +9,26 @@ import SectionHeader from '../components/SectionHeader.astro';
 import ThemeToggle from '../components/ThemeToggle.astro';
 import Layout from '../layouts/Layout.astro';
 
+// Entity data for search engines: ties the-guild.dev to every property
+// The Guild owns. See the SEO audit — the entity ranks #12 for its own name.
+const organizationJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'The Guild',
+  url: 'https://the-guild.dev/',
+  logo: 'https://the-guild.dev/android-chrome-512x512.png',
+  sameAs: [
+    'https://github.com/the-guild-org',
+    'https://github.com/graphql-hive',
+    'https://twitter.com/TheGuildDev',
+    'https://www.linkedin.com/company/the-guild-software/',
+    'https://discord.com/invite/xud7bH9',
+    'https://graphql-hive.com',
+    'https://stellate.co',
+    'https://grafbase.com',
+  ],
+});
+
 const stellateAcquisitionHref = '/graphql/hive/blog/stellate-acquisition';
 const grafbaseAcquisitionHref = '/graphql/hive/blog/acquired-grafbase';
 const benchmarksHref = '/graphql/hive/federation-gateway-performance';
@@ -145,6 +165,7 @@ const stellateCaseStudies = [
   title="The Guild: GraphQL infrastructure for teams that ship"
   description="Open-source GraphQL infrastructure for enterprises, built and maintained by The Guild."
 >
+  <script is:inline slot="head" type="application/ld+json" set:html={organizationJsonLd} />
   <header
     class="sticky top-0 z-20 border-b border-[var(--line)] bg-[var(--nav-bg)] backdrop-blur-[10px]"
   >

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+const SITE = 'https://the-guild.dev';
+
+// Root-level llms.txt: an index of The Guild's ecosystem for agents and
+// crawlers. The Hive docs ship their own, much deeper one under
+// /graphql/hive/llms.txt; the product sites are separate deployments and are
+// linked rather than inlined.
+export const GET: APIRoute = async () => {
+  const posts = (await getCollection('blog')).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+  );
+
+  const body = `# The Guild
+
+> Open-source GraphQL infrastructure for enterprises: the Hive federation
+> platform (schema registry, gateway, observability) and the most-used
+> open-source GraphQL libraries (GraphQL Codegen, Yoga, GraphQL-Tools, Mesh).
+
+## Hive — GraphQL Federation Platform
+
+- [Hive](${SITE}/graphql/hive): open-source schema registry, gateway and observability
+- [Hive documentation index for LLMs](${SITE}/graphql/hive/llms.txt)
+- [Full Hive documentation as one file](${SITE}/graphql/hive/llms-full.txt)
+- [Pricing](${SITE}/graphql/hive/pricing)
+- [GraphQL federation explained](${SITE}/graphql/hive/federation)
+
+## Open-source libraries
+
+- [GraphQL Codegen](${SITE}/graphql/codegen): typed code from GraphQL schemas and operations
+- [GraphQL Yoga](${SITE}/graphql/yoga-server): spec-compliant GraphQL server
+- [GraphQL-Tools](${SITE}/graphql/tools): schema building and stitching utilities
+- [GraphQL Mesh](${SITE}/graphql/mesh): compose any API into a graph
+- [GraphQL Scalars](${SITE}/graphql/scalars): custom scalar types
+- [GraphQL Inspector](${SITE}/graphql/inspector): schema change validation
+
+## Blog
+
+${posts.map(post => `- [${post.data.title}](${SITE}/blog/${post.id}): ${post.data.description}`).join('\n')}
+`;
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
Implements the remaining "stop the bleeding" items from the 1 Sept search audit. (SEO-01's sitemap defects — orphaned Hive sitemap, 404 `<loc>`s — were already fixed by the site unification; verified live.)

**SEO-02 — migrated blog slugs.** 131 old `/blog/<slug>` URLs now 301 to their `/graphql/hive/blog/<slug>` homes. The rules are derived from the built output at postbuild time (slug exists in the Hive blog and not in the root blog), so future posts are covered automatically and real root posts can never be shadowed. The 404 page also stops emitting `<link rel="canonical" href="/404">`.

**SEO-03 — dead-URL families.** `/docs/*`, `/product-updates/*`, `/case-studies/*` 301 to their Hive locations via `_redirects`. The route-template leaks (`/_landing/...`, literal `$` segments) get **410** from the router worker — Pages `_redirects` can't express 410 — via a unit-tested predicate. (The typedoc family lives under `/graphql/tools`, which routes to the Tools site's own deployment — needs fixing there.)

**SEO-05 — entity data.** `Organization` JSON-LD on the homepage with `sameAs` across GitHub orgs, socials, graphql-hive.com, stellate.co and grafbase.com; `SoftwareApplication` on the Hive landing.

**SEO-07 — root `/llms.txt`.** An ecosystem index generated from the blog collection, linking the deep Hive `llms.txt`/`llms-full.txt` and the product sites.

**The recurrence guard.** A new build gate verifies every `<loc>` in both sitemaps resolves to a built file and that the index references both children — 596 URLs verified per build. This is the audit's "CI check that every sitemap URL returns 200", enforced where it's cheapest.

Verified on the built site: llms.txt serves, the 404 has no canonical, both JSON-LD blocks present, `_redirects` contains 131 slug rules + 3 family splats with correct precedence, all verifiers green, astro check/lint/prettier/tests pass.

Still manual/elsewhere: the `Home (GraphQL-Codegen)` title (Codegen repo), Search Console verification of stellate.co/grafbase.com, and GSC "validate fix" runs once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic redirects for migrated Hive content and legacy documentation, product update, and case study URLs.
  - Added a root-level `llms.txt` resource with links to documentation, libraries, Hive, and blog content.
  - Added structured metadata for The Guild and Hive to improve search and preview information.

- **Bug Fixes**
  - Requests using leaked route-template URLs now return `410 Gone`.
  - Not-found pages no longer generate misleading canonical URLs.

- **Chores**
  - Added sitemap validation during website builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->