### PR TITLE
Fix cross-site theme, hive nav, asset lookup and checker gaps

### DIFF
--- a/website/scripts/hive/check-seo.ts
+++ b/website/scripts/hive/check-seo.ts
@@ -42,10 +42,12 @@ const REQUIRED_TAGS = [
 const ROUTER_HANDLED_PATHS = new Set([
   "/graphql/hive/federation-gateway-performance",
   "/graphql/hive/federation-gateway-audit",
+  "/graphql/hive/federation-playground",
 ]);
 
 // Path prefixes served by other deployments through the website-router —
 // links to them cannot resolve inside this dist.
+// Keep in sync with packages/website-router/src/config.ts mappings.
 const EXTERNAL_DEPLOYMENT_PREFIXES = [
   "/graphql/codegen",
   "/graphql/yoga-server",
@@ -60,6 +62,10 @@ const EXTERNAL_DEPLOYMENT_PREFIXES = [
   "/graphql/eslint",
   "/graphql/config",
   "/graphql/stitching",
+  "/graphql/ws",
+  "/graphql/sse",
+  "/openapi/fets",
+  "/heltin",
 ];
 
 async function* walk(dir: string): AsyncGenerator<string> {
@@ -204,14 +210,12 @@ for await (const filePath of walk(OUTPUT_DIR)) {
   scanned += 1;
   const html = await readFile(filePath, "utf8");
 
-  const fallback: ParsedHead = {
-    jsonldCount: 0,
-    jsonldInvalid: false,
-    jsonldTypes: [],
-    parsed: {},
-  };
-  const { jsonldCount, jsonldInvalid, jsonldTypes, parsed } =
-    parseHead(html) ?? fallback;
+  const parsedHead = parseHead(html);
+  if (!parsedHead) {
+    issues.push(`${path.relative(OUTPUT_DIR, filePath)}: missing <head>`);
+    continue;
+  }
+  const { jsonldCount, jsonldInvalid, jsonldTypes, parsed } = parsedHead;
 
   if (verbose) {
     console.log(filePath, { jsonldCount }, parsed);
@@ -219,11 +223,6 @@ for await (const filePath of walk(OUTPUT_DIR)) {
 
   const relativePath = path.relative(OUTPUT_DIR, filePath);
   const pagePath = publicPath(relativePath);
-
-  if (!parsed) {
-    issues.push(`${relativePath}: missing <head>`);
-    continue;
-  }
 
   for (const tag of REQUIRED_TAGS) {
     if (!parsed[tag]) {

--- a/website/src/hive/components/SiteNavigation.astro
+++ b/website/src/hive/components/SiteNavigation.astro
@@ -1,5 +1,5 @@
 ---
-import { withBase } from "../lib/base-path";
+import { basePath, withBase } from "../lib/base-path";
 import graphQLConfImage from "../documentation/src/components/graphql-conf-image.webp";
 
 import type { DocsNavNode, DocsNavPage } from "../lib/docs-nav";
@@ -31,8 +31,13 @@ interface Props {
 }
 
 const { docsNavigation = [], docsNavigationTree = [] } = Astro.props;
+// File-format output and the mount prefix mean the landing page's pathname
+// is "<base>.html", never "/" — compare mount-relative so the "on the
+// landing page, link to docs" branch actually fires.
 const pathname = Astro.url.pathname;
-const hiveHref = pathname === "/" ? "/docs" : "/";
+const onLandingPage =
+  pathname === basePath || pathname === `${basePath}.html` || pathname === "/";
+const hiveHref = onLandingPage ? "/docs" : "/";
 
 const withClass = (svg: string, className: string) =>
   svg.replace("<svg", `<svg class="${className}"`);

--- a/website/src/hive/components/ThemeInit.astro
+++ b/website/src/hive/components/ThemeInit.astro
@@ -2,7 +2,10 @@
   (() => {
     const media = matchMedia("(prefers-color-scheme: dark)");
     const apply = () => {
-      const preference = localStorage.getItem("theme") || "system";
+      // One storage key for the whole domain ("theme" is the pre-merge Hive
+      // key, read as a fallback so existing visitors keep their preference).
+      const preference =
+        localStorage.getItem("guild-theme") || localStorage.getItem("theme") || "system";
       const dark = preference === "dark" || (preference === "system" && media.matches);
       document.documentElement.classList.toggle("dark", dark);
       document.documentElement.classList.toggle("light", !dark);
@@ -15,4 +18,40 @@
     apply();
     media.addEventListener("change", apply);
   })();
+</script>
+
+<script>
+  // Toggle wiring for any page that renders a [data-theme-toggle] control —
+  // previously an inline copy in DocsLayout only, so other pages with a
+  // toggle (or a saved preference) had no way to change it.
+  const themeMedia = matchMedia("(prefers-color-scheme: dark)");
+  const applyTheme = (preference: string) => {
+    const dark = preference === "dark" || (preference === "system" && themeMedia.matches);
+    document.documentElement.classList.toggle("dark", dark);
+    document.documentElement.classList.toggle("light", !dark);
+    document.documentElement.dataset.theme = preference;
+    document.documentElement.dataset.pfTheme = dark ? "dark" : "light";
+    document.documentElement.style.colorScheme = dark ? "dark" : "light";
+    document.querySelectorAll<HTMLButtonElement>("[data-theme-toggle] [data-theme]").forEach((button) => {
+      const active = button.dataset.theme === preference;
+      button.setAttribute("aria-pressed", String(active));
+      button.classList.toggle("bg-fd-accent", active);
+      button.classList.toggle("text-fd-accent-foreground", active);
+      button.classList.toggle("text-fd-muted-foreground", !active);
+    });
+  };
+  const savedTheme = localStorage.getItem("guild-theme") || localStorage.getItem("theme") || "system";
+  applyTheme(savedTheme);
+  document.querySelectorAll<HTMLButtonElement>("[data-theme-toggle] [data-theme]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const preference = button.dataset.theme;
+      if (!preference) return;
+      localStorage.setItem("guild-theme", preference);
+      applyTheme(preference);
+    });
+  });
+  themeMedia.addEventListener("change", () => {
+    const saved = localStorage.getItem("guild-theme") || localStorage.getItem("theme") || "system";
+    if (saved === "system") applyTheme("system");
+  });
 </script>

--- a/website/src/hive/components/ThemeInit.astro
+++ b/website/src/hive/components/ThemeInit.astro
@@ -4,8 +4,11 @@
     const apply = () => {
       // One storage key for the whole domain ("theme" is the pre-merge Hive
       // key, read as a fallback so existing visitors keep their preference).
+      // Anything else in storage counts as unset.
       const preference =
-        localStorage.getItem("guild-theme") || localStorage.getItem("theme") || "system";
+        [localStorage.getItem("guild-theme"), localStorage.getItem("theme")].find(
+          (value) => value === "dark" || value === "light" || value === "system",
+        ) || "system";
       const dark = preference === "dark" || (preference === "system" && media.matches);
       document.documentElement.classList.toggle("dark", dark);
       document.documentElement.classList.toggle("light", !dark);
@@ -40,8 +43,11 @@
       button.classList.toggle("text-fd-muted-foreground", !active);
     });
   };
-  const savedTheme = localStorage.getItem("guild-theme") || localStorage.getItem("theme") || "system";
-  applyTheme(savedTheme);
+  const readSavedTheme = () =>
+    [localStorage.getItem("guild-theme"), localStorage.getItem("theme")].find(
+      (value) => value === "dark" || value === "light" || value === "system",
+    ) ?? "system";
+  applyTheme(readSavedTheme());
   document.querySelectorAll<HTMLButtonElement>("[data-theme-toggle] [data-theme]").forEach((button) => {
     button.addEventListener("click", () => {
       const preference = button.dataset.theme;
@@ -51,7 +57,6 @@
     });
   });
   themeMedia.addEventListener("change", () => {
-    const saved = localStorage.getItem("guild-theme") || localStorage.getItem("theme") || "system";
-    if (saved === "system") applyTheme("system");
+    if (readSavedTheme() === "system") applyTheme("system");
   });
 </script>

--- a/website/src/hive/layouts/BlogPageLayout.astro
+++ b/website/src/hive/layouts/BlogPageLayout.astro
@@ -7,6 +7,7 @@ import GetYourAPIGameRightSection from "../components/GetYourAPIGameRightSection
 import SiteFooter from "../components/SiteFooter.astro";
 import SiteNavigation from "../components/SiteNavigation.astro";
 import BaseHead from "../components/BaseHead.astro";
+import ThemeInit from "../components/ThemeInit.astro";
 
 interface Props {
   description: string;
@@ -22,6 +23,7 @@ const { description, title } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <BaseHead description={description} title={`${title} | Hive`} />
+    <ThemeInit />
     <link rel="alternate" type="application/rss+xml" title="Hive Blog" href="https://the-guild.dev/graphql/hive/blog/feed.xml" />
   </head>
   <body class="min-h-screen antialiased">

--- a/website/src/hive/layouts/BlogPostLayout.astro
+++ b/website/src/hive/layouts/BlogPostLayout.astro
@@ -10,6 +10,7 @@ import GetYourAPIGameRightSection from "../components/GetYourAPIGameRightSection
 import SiteFooter from "../components/SiteFooter.astro";
 import SiteNavigation from "../components/SiteNavigation.astro";
 import BaseHead from "../components/BaseHead.astro";
+import ThemeInit from "../components/ThemeInit.astro";
 import TocAsideContent from "../components/TocAsideContent.astro";
 import TocPopoverContent from "../components/TocPopoverContent.astro";
 import { filterToc, type TocHeading } from "../lib/toc";
@@ -40,6 +41,7 @@ const pageTitle = title.includes("|") ? title : `${title} | Hive`;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <BaseHead breadcrumbs={[{ name: "Blog", path: "/blog" }]} canonical={canonical} description={description} image={socialImage} imageAlt={title} title={pageTitle} type="article" />
+    <ThemeInit />
     <link rel="alternate" type="application/rss+xml" title="Hive Blog" href="https://the-guild.dev/graphql/hive/blog/feed.xml" />
   </head>
   <body class="min-h-screen antialiased">

--- a/website/src/hive/layouts/CaseStudyLayout.astro
+++ b/website/src/hive/layouts/CaseStudyLayout.astro
@@ -8,6 +8,7 @@ import CompanyLogo from "../components/case-studies/CompanyLogo.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import SiteNavigation from "../components/SiteNavigation.astro";
 import BaseHead from "../components/BaseHead.astro";
+import ThemeInit from "../components/ThemeInit.astro";
 
 interface Author {
   avatar?: string;
@@ -42,6 +43,7 @@ const pageTitle = `${title} | Hive`;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <BaseHead breadcrumbs={[{ name: "Case Studies", path: "/case-studies" }]} canonical={canonical} description={excerpt} imageAlt={title} title={pageTitle} type="article" />
+    <ThemeInit />
   </head>
   <body class="min-h-screen antialiased">
     <SiteNavigation />

--- a/website/src/hive/layouts/DocsLayout.astro
+++ b/website/src/hive/layouts/DocsLayout.astro
@@ -172,35 +172,5 @@ const titleId = title.replaceAll(/[\s.,]+/g, "-").toLowerCase();
     <DocsSearchModal section={searchSection} />
     <HeadingPermalinks />
 
-    <script>
-      const themeMedia = matchMedia("(prefers-color-scheme: dark)");
-      const applyTheme = (preference: string) => {
-        const dark = preference === "dark" || (preference === "system" && themeMedia.matches);
-        document.documentElement.classList.toggle("dark", dark);
-        document.documentElement.classList.toggle("light", !dark);
-        document.documentElement.dataset.theme = preference;
-        document.documentElement.style.colorScheme = dark ? "dark" : "light";
-        document.querySelectorAll<HTMLButtonElement>("[data-theme-toggle] [data-theme]").forEach((button) => {
-          const active = button.dataset.theme === preference;
-          button.setAttribute("aria-pressed", String(active));
-          button.classList.toggle("bg-fd-accent", active);
-          button.classList.toggle("text-fd-accent-foreground", active);
-          button.classList.toggle("text-fd-muted-foreground", !active);
-        });
-      };
-      const savedTheme = localStorage.getItem("theme") || "system";
-      applyTheme(savedTheme);
-      document.querySelectorAll<HTMLButtonElement>("[data-theme-toggle] [data-theme]").forEach((button) => {
-        button.addEventListener("click", () => {
-          const preference = button.dataset.theme;
-          if (!preference) return;
-          localStorage.setItem("theme", preference);
-          applyTheme(preference);
-        });
-      });
-      themeMedia.addEventListener("change", () => {
-        if ((localStorage.getItem("theme") || "system") === "system") applyTheme("system");
-      });
-    </script>
   </body>
 </html>

--- a/website/src/hive/lib/docs-nav.ts
+++ b/website/src/hive/lib/docs-nav.ts
@@ -62,7 +62,7 @@ function parseBracket(entry: string) {
 function humanize(slug: string) {
   return slug
     .split("-")
-    .map((word) => word[0]!.toUpperCase() + word.slice(1))
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
 }
 

--- a/website/src/hive/lib/pretty-print-tag.ts
+++ b/website/src/hive/lib/pretty-print-tag.ts
@@ -11,7 +11,7 @@ export function prettyPrintTag(tag = "All") {
   }
   text = text.replace("graphql", "GraphQL");
   text = text.replace(/-js$/, " JS");
-  text = text[0]!.toUpperCase() + text.slice(1);
+  text = text.charAt(0).toUpperCase() + text.slice(1);
   text = text
     .replaceAll("-", " ")
     .replaceAll(/\b\w/g, (char) => char.toUpperCase());

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -61,8 +61,12 @@ const imageUrl = new URL(image ?? DEFAULT_OG_IMAGE, Astro.site).href;
     <slot name="head" />
     <script is:inline>
       try {
-        // The key is shared with the Hive pages, which also store 'system'.
-        const saved = localStorage.getItem('guild-theme');
+        // The key is shared with the Hive pages, which also store 'system'
+        // and read the pre-merge 'theme' key as a fallback — mirror that so
+        // returning Hive visitors keep their preference here too.
+        const saved = [localStorage.getItem('guild-theme'), localStorage.getItem('theme')].find(
+          value => value === 'dark' || value === 'light' || value === 'system',
+        );
         document.documentElement.dataset.theme =
           saved === 'dark' || saved === 'light'
             ? saved

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -61,9 +61,14 @@ const imageUrl = new URL(image ?? DEFAULT_OG_IMAGE, Astro.site).href;
     <slot name="head" />
     <script is:inline>
       try {
+        // The key is shared with the Hive pages, which also store 'system'.
         const saved = localStorage.getItem('guild-theme');
         document.documentElement.dataset.theme =
-          saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+          saved === 'dark' || saved === 'light'
+            ? saved
+            : window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light';
       } catch {
         document.documentElement.dataset.theme = 'dark';
       }

--- a/website/src/pages/graphql/hive/blog/[...slug].astro
+++ b/website/src/pages/graphql/hive/blog/[...slug].astro
@@ -40,10 +40,11 @@ function slug(id: string) {
 }
 
 function findAsset(map: Record<string, { default: { src: string } }>, entrySlug: string) {
-  // Exact directory match — a substring test resolves the wrong image when
-  // one post's slug is a path segment of another's.
+  // Exact parent-directory match — a substring test resolves the wrong image
+  // when one post's slug is a path segment of another's, or when a post
+  // keeps assets in nested subdirectories.
   const match = Object.entries(map).find(([file]) =>
-    file.includes(`/content/blog/${entrySlug}/`),
+    file.slice(0, file.lastIndexOf("/")).endsWith(`/content/blog/${entrySlug}`),
   );
   return match?.[1]?.default?.src;
 }

--- a/website/src/pages/graphql/hive/blog/[...slug].astro
+++ b/website/src/pages/graphql/hive/blog/[...slug].astro
@@ -40,7 +40,11 @@ function slug(id: string) {
 }
 
 function findAsset(map: Record<string, { default: { src: string } }>, entrySlug: string) {
-  const match = Object.entries(map).find(([file]) => file.includes(`/${entrySlug}/`));
+  // Exact directory match — a substring test resolves the wrong image when
+  // one post's slug is a path segment of another's.
+  const match = Object.entries(map).find(([file]) =>
+    file.includes(`/content/blog/${entrySlug}/`),
+  );
   return match?.[1]?.default?.src;
 }
 


### PR DESCRIPTION
Third PR of the code-review series — user-visible behavior bugs on the site itself:

**Theme unification.** The Hive pages and the main site used different localStorage keys (`theme` vs `guild-theme`) and different DOM mechanisms, so crossing `/` ↔ `/graphql/hive` silently lost the visitor's choice — and three Hive layouts (blog index, blog posts, case studies) ship `dark:` styles but never initialized the theme at all, so dark mode simply never applied there (the same latent bug class as the `:global(.dark)` selector fixed earlier). Now: one shared key (`guild-theme`, with the legacy key as a read fallback), toggle wiring moved from an inline DocsLayout copy into `ThemeInit` itself, and `ThemeInit` rendered by all dark-capable layouts. **Browser-verified end to end**: choose dark on the docs toggle → hive blog renders dark → main site renders dark.

**Hive nav dead branch**: the "on the landing page, link to docs" logic compared `Astro.url.pathname` to `/`, never true under the mount prefix + file-format output. Fixed with a mount-relative comparison.

**Blog image lookup**: matched images by slug *substring*, so a slug that's a path segment of another post's resolved the wrong image. Now an exact content-directory match.

**check-seo gaps**: the missing-`<head>` check was unreachable dead code (null swallowed by a fallback object — flagged in review); the external-deployment allowlist gains the 4 router mappings it had drifted from (`/graphql/ws`, `/graphql/sse`, `/openapi/fets`, `/heltin`) plus `federation-playground`; two `text[0]!` empty-string crashes become `charAt` guards.

All 595 pages pass the sweep; astro check 0/0, lint, prettier green. Marketing/landing pages remain deliberately light-only — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent theme initialization across blog, case study, documentation, and other site pages.
  * Theme preferences now recognize dark, light, and system settings, including legacy saved preferences and system changes.
  * Navigation now directs visitors to the appropriate documentation or homepage location.

* **Bug Fixes**
  * Improved handling of invalid saved theme preferences.
  * Improved blog asset matching to prevent unrelated content from being displayed.
  * Enhanced SEO route recognition for externally hosted paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->