### PR TITLE
One source of truth for site constants, path aliases, hive schemas

### DIFF
--- a/website/scripts/hive/check-seo.ts
+++ b/website/scripts/hive/check-seo.ts
@@ -10,10 +10,10 @@ import { existsSync, readFileSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { SITE_ORIGIN as SITE } from '../../src/hive/lib/base-path.ts';
 
 const verbose = process.env['VERBOSE'] === 'true' || process.argv.includes('--verbose');
 
-const SITE = 'https://the-guild.dev';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR = path.resolve(__dirname, '../../dist');
 

--- a/website/scripts/hive/generate-redirects.ts
+++ b/website/scripts/hive/generate-redirects.ts
@@ -2,17 +2,17 @@ import { globSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { routeRules } from '../../src/hive/documentation/redirects.ts';
-
-const outputDirectory = fileURLToPath(new URL('../../dist', import.meta.url));
-const outputFile = fileURLToPath(new URL('../../dist/_redirects', import.meta.url));
-
 /**
  * The Hive site is mounted at /graphql/hive of the unified deployment, and
  * Cloudflare Pages only reads root-level _redirects — so every rule is
  * written with the mount prefix. Redirect sources/destinations in
  * redirects.ts stay un-prefixed (they predate the merge and read naturally).
  */
-const PREFIX = '/graphql/hive';
+import { basePath as PREFIX } from '../../src/hive/lib/base-path.ts';
+
+const outputDirectory = fileURLToPath(new URL('../../dist', import.meta.url));
+const outputFile = fileURLToPath(new URL('../../dist/_redirects', import.meta.url));
+
 const prefixPath = (path: string) =>
   path.startsWith('/') && !path.startsWith(PREFIX) ? `${PREFIX}${path}` : path;
 

--- a/website/scripts/hive/generate-sitemap.ts
+++ b/website/scripts/hive/generate-sitemap.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from 'node:child_process';
 import { globSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { HIVE_SITE_URL as SITE_URL } from '../../src/hive/lib/base-path.ts';
 
-const SITE_URL = 'https://the-guild.dev/graphql/hive';
 const distDirectory = fileURLToPath(new URL('../../dist/graphql/hive', import.meta.url));
 const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
 

--- a/website/scripts/hive/verify-base-path.ts
+++ b/website/scripts/hive/verify-base-path.ts
@@ -7,8 +7,8 @@
  */
 import { existsSync, globSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { basePath as base } from '../../src/hive/lib/base-path.ts';
 
-const base = '/graphql/hive';
 const projectDirectory = fileURLToPath(new URL('../..', import.meta.url));
 const distDirectory = fileURLToPath(new URL('../../dist', import.meta.url));
 const hiveDistDirectory = `${distDirectory}/graphql/hive`;

--- a/website/scripts/verify-sitemaps.mjs
+++ b/website/scripts/verify-sitemaps.mjs
@@ -6,8 +6,8 @@
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { SITE_ORIGIN as SITE } from '../src/hive/lib/base-path.ts';
 
-const SITE = 'https://the-guild.dev';
 const dist = fileURLToPath(new URL('../dist', import.meta.url));
 
 /** Maps a public path to the dist file that serves it (build.format: 'file'). */

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -52,7 +52,9 @@ const hiveAuthor = z.union([
     .object({ avatar: z.string().optional(), name: z.string(), position: z.string().optional() })
     .passthrough(),
 ]);
-const hiveDate = z.union([z.date(), z.string()]);
+// String dates must be ISO days — the product-updates page sorts them
+// lexically and parses them with `new Date(`${date}T00:00:00Z`)`.
+const hiveDate = z.union([z.date(), z.string().regex(/^\d{4}-\d{2}-\d{2}$/)]);
 
 const docs = defineCollection({
   loader: glob({

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -40,12 +40,33 @@ function generateHiveId({ entry }: { entry: string }) {
   return entry.replace(/\.(md|mdx)$/, '');
 }
 
+/**
+ * Hive frontmatter schemas, derived from the shapes every consumer was
+ * previously asserting with `as` casts. passthrough() keeps unknown legacy
+ * keys instead of stripping them; unions reflect real frontmatter variance
+ * in the 400+ migrated files (string vs array authors, string vs date).
+ */
+const hiveAuthor = z.union([
+  z.string(),
+  z
+    .object({ avatar: z.string().optional(), name: z.string(), position: z.string().optional() })
+    .passthrough(),
+]);
+const hiveDate = z.union([z.date(), z.string()]);
+
 const docs = defineCollection({
   loader: glob({
     base: `${hiveContentRoot}/docs`,
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
+  schema: z
+    .object({
+      title: z.string().optional(),
+      sidebarTitle: z.string().optional(),
+      description: z.string().optional(),
+    })
+    .passthrough(),
 });
 
 const productUpdates = defineCollection({
@@ -54,6 +75,15 @@ const productUpdates = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
+  schema: z
+    .object({
+      title: z.string(),
+      description: z.string(),
+      date: hiveDate,
+      authors: z.array(hiveAuthor),
+      canonical: z.string().optional(),
+    })
+    .passthrough(),
 });
 
 const caseStudies = defineCollection({
@@ -62,6 +92,16 @@ const caseStudies = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
+  schema: z
+    .object({
+      title: z.string(),
+      excerpt: z.string(),
+      category: z.string(),
+      date: hiveDate,
+      authors: z.array(hiveAuthor).optional(),
+      canonical: z.string().optional(),
+    })
+    .passthrough(),
 });
 
 const hiveBlog = defineCollection({
@@ -70,6 +110,18 @@ const hiveBlog = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
+  schema: z
+    .object({
+      title: z.string(),
+      description: z.string().optional(),
+      date: hiveDate,
+      authors: z.union([z.string(), z.array(hiveAuthor)]),
+      tags: z.array(z.string()).default([]),
+      featured: z.boolean().optional(),
+      canonical: z.string().optional(),
+      ogImage: z.string().optional(),
+    })
+    .passthrough(),
 });
 
 export const collections = { blog, caseStudies, docs, hiveBlog, productUpdates };

--- a/website/src/hive/components/BaseHead.astro
+++ b/website/src/hive/components/BaseHead.astro
@@ -5,7 +5,7 @@
  * preloads, and the page title. Included by every page's <head>.
  */
 import type { ImageMetadata } from 'astro';
-import { basePath, withBase } from '../lib/base-path';
+import { basePath, SITE_ORIGIN, HIVE_SITE_URL as SITE_URL, withBase } from '../lib/base-path';
 import FontPreloads from './FontPreloads.astro';
 import defaultImage from '../documentation/src/routes/opengraph-image.png';
 
@@ -26,8 +26,7 @@ interface Props {
 }
 
 const SITE_NAME = 'Hive';
-const SITE_ORIGIN = 'https://the-guild.dev';
-const SITE_URL = `${SITE_ORIGIN}/graphql/hive`;
+
 const TWITTER_ACCOUNT = '@TheGuildDev';
 
 const {

--- a/website/src/hive/lib/base-path.ts
+++ b/website/src/hive/lib/base-path.ts
@@ -5,7 +5,10 @@
  * external URLs, anchors, and already-prefixed paths, so it is safe to apply
  * to any href/src value.
  */
+export const SITE_ORIGIN = 'https://the-guild.dev';
 export const basePath = '/graphql/hive';
+/** Absolute URL of the Hive site's mount point. */
+export const HIVE_SITE_URL = `${SITE_ORIGIN}${basePath}`;
 
 export function withBase(path: string): string;
 export function withBase(path: string | undefined): string | undefined;

--- a/website/src/hive/lib/llms.ts
+++ b/website/src/hive/lib/llms.ts
@@ -1,8 +1,7 @@
+import { HIVE_SITE_URL as SITE_URL } from './base-path';
 import type { DocsEntry } from './docs-markdown';
 import { getDocsSlug } from './docs-markdown';
 import type { DocsNavNode, DocsNavPage } from './docs-nav';
-
-const SITE_URL = 'https://the-guild.dev/graphql/hive';
 
 function flattenPages(node: DocsNavNode): DocsNavPage[] {
   if (node.type === 'page') return [node];

--- a/website/src/lib/hive-feed.ts
+++ b/website/src/lib/hive-feed.ts
@@ -2,9 +2,8 @@
 // directly instead of fetching the production RSS feed — a build-time fetch
 // of our own deployment is circular: if production is down or stale, the
 // build that would fix it can't complete.
+import { HIVE_SITE_URL } from '../hive/lib/base-path';
 import { getBlogPosts } from '../hive/lib/get-blog-posts';
-
-const HIVE_SITE_URL = 'https://the-guild.dev/graphql/hive';
 
 export interface HiveFeedItem {
   title: string;

--- a/website/src/pages/graphql/hive/blog/[...slug].astro
+++ b/website/src/pages/graphql/hive/blog/[...slug].astro
@@ -1,25 +1,25 @@
 ---
+import CodeBlock from '~hive/components/mdx/CodeBlock.astro';
+import Link from '~hive/components/mdx/Link.astro';
+import PackageManagerTabs from '~hive/components/mdx/PackageManagerTabs.astro';
+import PackageManagerTab from '~hive/components/mdx/Tab.astro';
+import BlogPostLayout from '~hive/layouts/BlogPostLayout.astro';
+import { getHeadingHtmlBySlug } from '~hive/lib/docs-markdown';
+import { getBlogPosts } from '~hive/lib/get-blog-posts';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
-import CodeBlock from '../../../../hive/components/mdx/CodeBlock.astro';
-import Link from '../../../../hive/components/mdx/Link.astro';
-import PackageManagerTabs from '../../../../hive/components/mdx/PackageManagerTabs.astro';
-import PackageManagerTab from '../../../../hive/components/mdx/Tab.astro';
-import BlogPostLayout from '../../../../hive/layouts/BlogPostLayout.astro';
-import { getHeadingHtmlBySlug } from '../../../../hive/lib/docs-markdown';
-import { getBlogPosts } from '../../../../hive/lib/get-blog-posts';
 
 type Blog = CollectionEntry<'hiveBlog'>;
 
 const headerImages = import.meta.glob<{ default: { src: string } }>(
-  '../../../../hive/documentation/content/blog/**/header-image.*',
+  '~hive/documentation/content/blog/**/header-image.*',
   { eager: true },
 );
 const mobileImages = import.meta.glob<{ default: { src: string } }>(
-  '../../../../hive/documentation/content/blog/**/mobile-image.*',
+  '~hive/documentation/content/blog/**/mobile-image.*',
   { eager: true },
 );
 const socialImages = import.meta.glob<{ default: { src: string } }>(
-  '../../../../hive/documentation/content/blog/**/opengraph-image.*',
+  '~hive/documentation/content/blog/**/opengraph-image.*',
   { eager: true },
 );
 

--- a/website/src/pages/graphql/hive/blog/feed.xml.ts
+++ b/website/src/pages/graphql/hive/blog/feed.xml.ts
@@ -1,8 +1,7 @@
+import { resolveAuthor } from '~hive/lib/authors';
+import { HIVE_SITE_URL as SITE_URL } from '~hive/lib/base-path';
+import { getBlogPosts } from '~hive/lib/get-blog-posts';
 import type { APIRoute } from 'astro';
-import { resolveAuthor } from '../../../../hive/lib/authors';
-import { getBlogPosts } from '../../../../hive/lib/get-blog-posts';
-
-const SITE_URL = 'https://the-guild.dev/graphql/hive';
 
 function escapeXml(value: string) {
   return value.replace(/[&<>'"]/g, char => {

--- a/website/src/pages/graphql/hive/blog/index.astro
+++ b/website/src/pages/graphql/hive/blog/index.astro
@@ -1,8 +1,8 @@
 ---
-import NewsletterFormCard from '../../../../hive/components/blog/NewsletterFormCard.astro';
-import PostsByTag from '../../../../hive/components/blog/PostsByTag.astro';
-import BlogPageLayout from '../../../../hive/layouts/BlogPageLayout.astro';
-import { getBlogPosts } from '../../../../hive/lib/get-blog-posts';
+import NewsletterFormCard from '~hive/components/blog/NewsletterFormCard.astro';
+import PostsByTag from '~hive/components/blog/PostsByTag.astro';
+import BlogPageLayout from '~hive/layouts/BlogPageLayout.astro';
+import { getBlogPosts } from '~hive/lib/get-blog-posts';
 
 const posts = await getBlogPosts();
 ---

--- a/website/src/pages/graphql/hive/blog/tag/[...tag].astro
+++ b/website/src/pages/graphql/hive/blog/tag/[...tag].astro
@@ -1,7 +1,7 @@
 ---
-import PostsByTag from '../../../../../hive/components/blog/PostsByTag.astro';
-import BlogPageLayout from '../../../../../hive/layouts/BlogPageLayout.astro';
-import { getBlogPosts } from '../../../../../hive/lib/get-blog-posts';
+import PostsByTag from '~hive/components/blog/PostsByTag.astro';
+import BlogPageLayout from '~hive/layouts/BlogPageLayout.astro';
+import { getBlogPosts } from '~hive/lib/get-blog-posts';
 
 export async function getStaticPaths() {
   const posts = await getBlogPosts();

--- a/website/src/pages/graphql/hive/case-studies/[...slug].astro
+++ b/website/src/pages/graphql/hive/case-studies/[...slug].astro
@@ -1,9 +1,9 @@
 ---
+import CodeBlock from '~hive/components/mdx/CodeBlock.astro';
+import PackageManagerTabs from '~hive/components/mdx/PackageManagerTabs.astro';
+import PackageManagerTab from '~hive/components/mdx/Tab.astro';
+import CaseStudyLayout from '~hive/layouts/CaseStudyLayout.astro';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
-import CodeBlock from '../../../../hive/components/mdx/CodeBlock.astro';
-import PackageManagerTabs from '../../../../hive/components/mdx/PackageManagerTabs.astro';
-import PackageManagerTab from '../../../../hive/components/mdx/Tab.astro';
-import CaseStudyLayout from '../../../../hive/layouts/CaseStudyLayout.astro';
 
 type CaseStudy = CollectionEntry<'caseStudies'>;
 

--- a/website/src/pages/graphql/hive/case-studies/index.astro
+++ b/website/src/pages/graphql/hive/case-studies/index.astro
@@ -1,12 +1,12 @@
 ---
+import BaseHead from '~hive/components/BaseHead.astro';
+import CaseStudyCard from '~hive/components/case-studies/CaseStudyCard.astro';
+import CaseStudyCta from '~hive/components/case-studies/CaseStudyCta.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
 import { getCollection } from 'astro:content';
-import BaseHead from '../../../../hive/components/BaseHead.astro';
-import CaseStudyCard from '../../../../hive/components/case-studies/CaseStudyCard.astro';
-import CaseStudyCta from '../../../../hive/components/case-studies/CaseStudyCta.astro';
-import SiteFooter from '../../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../../hive/lib/base-path';
-import '../../../../hive/styles/global.css';
+import '~hive/styles/global.css';
 
 const caseStudies = (await getCollection('caseStudies'))
   .map(entry => {

--- a/website/src/pages/graphql/hive/docs.md.ts
+++ b/website/src/pages/graphql/hive/docs.md.ts
@@ -1,5 +1,5 @@
+import { getDocsSlug, markdownResponse } from '~hive/lib/docs-markdown';
 import { getCollection } from 'astro:content';
-import { getDocsSlug, markdownResponse } from '../../../hive/lib/docs-markdown';
 
 export const prerender = true;
 

--- a/website/src/pages/graphql/hive/docs/[...slug].astro
+++ b/website/src/pages/graphql/hive/docs/[...slug].astro
@@ -1,16 +1,16 @@
 ---
+import Callout from '~hive/components/mdx/Callout.astro';
+import Card from '~hive/components/mdx/Card.astro';
+import Cards from '~hive/components/mdx/Cards.astro';
+import CodeBlock from '~hive/components/mdx/CodeBlock.astro';
+import Image from '~hive/components/mdx/Image.astro';
+import PackageManagerTabs from '~hive/components/mdx/PackageManagerTabs.astro';
+import PackageManagerTab from '~hive/components/mdx/Tab.astro';
+import Table from '~hive/components/mdx/Table.astro';
+import DocsLayout from '~hive/layouts/DocsLayout.astro';
+import { getDocsSlug, getHeadingHtmlBySlug } from '~hive/lib/docs-markdown';
+import { getDocsNav } from '~hive/lib/docs-nav';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
-import Callout from '../../../../hive/components/mdx/Callout.astro';
-import Card from '../../../../hive/components/mdx/Card.astro';
-import Cards from '../../../../hive/components/mdx/Cards.astro';
-import CodeBlock from '../../../../hive/components/mdx/CodeBlock.astro';
-import Image from '../../../../hive/components/mdx/Image.astro';
-import PackageManagerTabs from '../../../../hive/components/mdx/PackageManagerTabs.astro';
-import PackageManagerTab from '../../../../hive/components/mdx/Tab.astro';
-import Table from '../../../../hive/components/mdx/Table.astro';
-import DocsLayout from '../../../../hive/layouts/DocsLayout.astro';
-import { getDocsSlug, getHeadingHtmlBySlug } from '../../../../hive/lib/docs-markdown';
-import { getDocsNav } from '../../../../hive/lib/docs-nav';
 
 type DocsEntry = CollectionEntry<'docs'>;
 

--- a/website/src/pages/graphql/hive/docs/[...slug].md.ts
+++ b/website/src/pages/graphql/hive/docs/[...slug].md.ts
@@ -1,5 +1,5 @@
+import { getDocsSlug, markdownResponse } from '~hive/lib/docs-markdown';
 import { getCollection, type CollectionEntry } from 'astro:content';
-import { getDocsSlug, markdownResponse } from '../../../../hive/lib/docs-markdown';
 
 type DocsEntry = CollectionEntry<'docs'>;
 

--- a/website/src/pages/graphql/hive/ecosystem.astro
+++ b/website/src/pages/graphql/hive/ecosystem.astro
@@ -1,11 +1,11 @@
 ---
-import BaseHead from '../../../hive/components/BaseHead.astro';
-import GotAnIdeaSection from '../../../hive/components/ecosystem/GotAnIdeaSection.astro';
-import ProductCard from '../../../hive/components/ecosystem/ProductCard.astro';
-import SiteFooter from '../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../hive/lib/base-path';
-import '../../../hive/styles/global.css';
+import BaseHead from '~hive/components/BaseHead.astro';
+import GotAnIdeaSection from '~hive/components/ecosystem/GotAnIdeaSection.astro';
+import ProductCard from '~hive/components/ecosystem/ProductCard.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
+import '~hive/styles/global.css';
 
 const lettermark = (mark: string) =>
   `<span role="img" class="inline-flex items-center justify-center text-xs font-medium">${mark}</span>`;

--- a/website/src/pages/graphql/hive/federation.astro
+++ b/website/src/pages/graphql/hive/federation.astro
@@ -1,16 +1,16 @@
 ---
-import BaseHead from '../../../hive/components/BaseHead.astro';
-import SiteFooter from '../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../hive/lib/base-path';
-import '../../../hive/styles/global.css';
-import federationDiagram from '../../../hive/documentation/src/routes/_landing/_light-only/federation/federation-diagram.png';
-import ogImage from '../../../hive/documentation/src/routes/_landing/_light-only/federation/opengraph-image.png';
-import queryResultImage from '../../../hive/documentation/src/routes/_landing/_light-only/federation/query-result.png';
-import queryImage from '../../../hive/documentation/src/routes/_landing/_light-only/federation/query.png';
-import subgraphsProductsImage from '../../../hive/documentation/src/routes/_landing/_light-only/federation/subgraphs-products.png';
-import subgraphsReviewsImage from '../../../hive/documentation/src/routes/_landing/_light-only/federation/subgraphs-reviews.png';
-import supergraphSchemaImage from '../../../hive/documentation/src/routes/_landing/_light-only/federation/supergraph-schema.png';
+import BaseHead from '~hive/components/BaseHead.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
+import '~hive/styles/global.css';
+import federationDiagram from '~hive/documentation/src/routes/_landing/_light-only/federation/federation-diagram.png';
+import ogImage from '~hive/documentation/src/routes/_landing/_light-only/federation/opengraph-image.png';
+import queryResultImage from '~hive/documentation/src/routes/_landing/_light-only/federation/query-result.png';
+import queryImage from '~hive/documentation/src/routes/_landing/_light-only/federation/query.png';
+import subgraphsProductsImage from '~hive/documentation/src/routes/_landing/_light-only/federation/subgraphs-products.png';
+import subgraphsReviewsImage from '~hive/documentation/src/routes/_landing/_light-only/federation/subgraphs-reviews.png';
+import supergraphSchemaImage from '~hive/documentation/src/routes/_landing/_light-only/federation/supergraph-schema.png';
 
 const faqs: [string, string[]][] = [
   [

--- a/website/src/pages/graphql/hive/feed.xml.ts
+++ b/website/src/pages/graphql/hive/feed.xml.ts
@@ -1,6 +1,5 @@
+import { HIVE_SITE_URL as SITE_URL } from '~hive/lib/base-path';
 import { getCollection } from 'astro:content';
-
-const SITE_URL = 'https://the-guild.dev/graphql/hive';
 
 function escapeXml(value: string) {
   return value.replace(/[&<>'"]/g, char => {

--- a/website/src/pages/graphql/hive/gateway.astro
+++ b/website/src/pages/graphql/hive/gateway.astro
@@ -1,19 +1,19 @@
 ---
-import BaseHead from '../../../hive/components/BaseHead.astro';
-import ExploreMainProductCards from '../../../hive/components/ExploreMainProductCards.astro';
-import FrequentlyAskedQuestions from '../../../hive/components/FrequentlyAskedQuestions.astro';
-import CloudNativeSection from '../../../hive/components/gateway/CloudNativeSection.astro';
-import FederationCompatibleBenchmarksSection from '../../../hive/components/gateway/FederationCompatibleBenchmarksSection.astro';
-import GatewayFeatureTabs from '../../../hive/components/gateway/GatewayFeatureTabs.astro';
-import LetsGetAdvancedSection from '../../../hive/components/gateway/LetsGetAdvancedSection.astro';
-import OrchestrateYourWay from '../../../hive/components/gateway/OrchestrateYourWay.astro';
-import GetYourAPIGameRightList from '../../../hive/components/GetYourAPIGameRightList.astro';
-import SiteFooter from '../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../hive/lib/base-path';
-import '../../../hive/styles/global.css';
-import checkIconRaw from '../../../hive/design-system/icons/check.svg?raw';
-import hiveGatewayIconRaw from '../../../hive/design-system/icons/hive-gateway.svg?raw';
+import BaseHead from '~hive/components/BaseHead.astro';
+import ExploreMainProductCards from '~hive/components/ExploreMainProductCards.astro';
+import FrequentlyAskedQuestions from '~hive/components/FrequentlyAskedQuestions.astro';
+import CloudNativeSection from '~hive/components/gateway/CloudNativeSection.astro';
+import FederationCompatibleBenchmarksSection from '~hive/components/gateway/FederationCompatibleBenchmarksSection.astro';
+import GatewayFeatureTabs from '~hive/components/gateway/GatewayFeatureTabs.astro';
+import LetsGetAdvancedSection from '~hive/components/gateway/LetsGetAdvancedSection.astro';
+import OrchestrateYourWay from '~hive/components/gateway/OrchestrateYourWay.astro';
+import GetYourAPIGameRightList from '~hive/components/GetYourAPIGameRightList.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
+import '~hive/styles/global.css';
+import checkIconRaw from '~hive/design-system/icons/check.svg?raw';
+import hiveGatewayIconRaw from '~hive/design-system/icons/hive-gateway.svg?raw';
 
 const withAttrs = (svg: string, attrs: string) => svg.replace('<svg', `<svg ${attrs}`);
 

--- a/website/src/pages/graphql/hive/index.astro
+++ b/website/src/pages/graphql/hive/index.astro
@@ -1,18 +1,18 @@
 ---
-import BaseHead from '../../../hive/components/BaseHead.astro';
-import FrequentlyAskedQuestions from '../../../hive/components/FrequentlyAskedQuestions.astro';
-import GetYourAPIGameRightSection from '../../../hive/components/GetYourAPIGameRightSection.astro';
-import CommunitySection from '../../../hive/components/landing/CommunitySection.astro';
-import CompanyLogo from '../../../hive/components/landing/CompanyLogo.astro';
-import CompanyTestimonials from '../../../hive/components/landing/CompanyTestimonials.astro';
-import EcosystemIllustration from '../../../hive/components/landing/EcosystemIllustration.astro';
-import FeatureTabs from '../../../hive/components/landing/FeatureTabs.astro';
-import TeamSection from '../../../hive/components/landing/TeamSection.astro';
-import ToolsAndLibraries from '../../../hive/components/landing/ToolsAndLibraries.astro';
-import SiteFooter from '../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../hive/lib/base-path';
-import '../../../hive/styles/global.css';
+import BaseHead from '~hive/components/BaseHead.astro';
+import FrequentlyAskedQuestions from '~hive/components/FrequentlyAskedQuestions.astro';
+import GetYourAPIGameRightSection from '~hive/components/GetYourAPIGameRightSection.astro';
+import CommunitySection from '~hive/components/landing/CommunitySection.astro';
+import CompanyLogo from '~hive/components/landing/CompanyLogo.astro';
+import CompanyTestimonials from '~hive/components/landing/CompanyTestimonials.astro';
+import EcosystemIllustration from '~hive/components/landing/EcosystemIllustration.astro';
+import FeatureTabs from '~hive/components/landing/FeatureTabs.astro';
+import TeamSection from '~hive/components/landing/TeamSection.astro';
+import ToolsAndLibraries from '~hive/components/landing/ToolsAndLibraries.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
+import '~hive/styles/global.css';
 
 const appUrl = 'https://app.graphql-hive.com';
 ---

--- a/website/src/pages/graphql/hive/llms-full.txt.ts
+++ b/website/src/pages/graphql/hive/llms-full.txt.ts
@@ -1,5 +1,5 @@
+import { getDocsMarkdown, getDocsSlug } from '~hive/lib/docs-markdown';
 import { getCollection } from 'astro:content';
-import { getDocsMarkdown, getDocsSlug } from '../../../hive/lib/docs-markdown';
 
 /**
  * The full documentation as one Markdown file for LLM consumption.

--- a/website/src/pages/graphql/hive/llms.txt.ts
+++ b/website/src/pages/graphql/hive/llms.txt.ts
@@ -1,6 +1,6 @@
+import { getDocsNav } from '~hive/lib/docs-nav';
+import { getLlmsText } from '~hive/lib/llms';
 import { getCollection } from 'astro:content';
-import { getDocsNav } from '../../../hive/lib/docs-nav';
-import { getLlmsText } from '../../../hive/lib/llms';
 
 export const prerender = true;
 

--- a/website/src/pages/graphql/hive/oss-friends.astro
+++ b/website/src/pages/graphql/hive/oss-friends.astro
@@ -1,9 +1,9 @@
 ---
-import BaseHead from '../../../hive/components/BaseHead.astro';
-import SiteFooter from '../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../hive/lib/base-path';
-import '../../../hive/styles/global.css';
+import BaseHead from '~hive/components/BaseHead.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
+import '~hive/styles/global.css';
 
 interface OSSFriend {
   description: string;

--- a/website/src/pages/graphql/hive/partners.astro
+++ b/website/src/pages/graphql/hive/partners.astro
@@ -1,12 +1,12 @@
 ---
-import BaseHead from '../../../hive/components/BaseHead.astro';
-import FrequentlyAskedQuestions from '../../../hive/components/FrequentlyAskedQuestions.astro';
-import GetYourAPIGameRightSection from '../../../hive/components/GetYourAPIGameRightSection.astro';
-import SiteFooter from '../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../hive/lib/base-path';
-import '../../../hive/styles/global.css';
-import ogImage from '../../../hive/documentation/src/routes/_landing/_light-only/partners.opengraph-image.png';
+import BaseHead from '~hive/components/BaseHead.astro';
+import FrequentlyAskedQuestions from '~hive/components/FrequentlyAskedQuestions.astro';
+import GetYourAPIGameRightSection from '~hive/components/GetYourAPIGameRightSection.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
+import '~hive/styles/global.css';
+import ogImage from '~hive/documentation/src/routes/_landing/_light-only/partners.opengraph-image.png';
 
 const partnersFaqs = [
   [

--- a/website/src/pages/graphql/hive/pricing.astro
+++ b/website/src/pages/graphql/hive/pricing.astro
@@ -1,13 +1,13 @@
 ---
-import BaseHead from '../../../hive/components/BaseHead.astro';
-import FrequentlyAskedQuestions from '../../../hive/components/FrequentlyAskedQuestions.astro';
-import GetYourAPIGameRightSection from '../../../hive/components/GetYourAPIGameRightSection.astro';
-import CompanyTestimonials from '../../../hive/components/landing/CompanyTestimonials.astro';
-import SiteFooter from '../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../hive/components/SiteNavigation.astro';
-import { withBase } from '../../../hive/lib/base-path';
-import '../../../hive/styles/global.css';
-import codeIconWhite from '../../../hive/documentation/src/components/code-icon-white.svg?url';
+import BaseHead from '~hive/components/BaseHead.astro';
+import FrequentlyAskedQuestions from '~hive/components/FrequentlyAskedQuestions.astro';
+import GetYourAPIGameRightSection from '~hive/components/GetYourAPIGameRightSection.astro';
+import CompanyTestimonials from '~hive/components/landing/CompanyTestimonials.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import { withBase } from '~hive/lib/base-path';
+import '~hive/styles/global.css';
+import codeIconWhite from '~hive/documentation/src/components/code-icon-white.svg?url';
 
 const appUrl = 'https://app.graphql-hive.com';
 const contactUrl = 'https://the-guild.dev/contact';

--- a/website/src/pages/graphql/hive/product-updates/[...slug].astro
+++ b/website/src/pages/graphql/hive/product-updates/[...slug].astro
@@ -1,13 +1,13 @@
 ---
+import Callout from '~hive/components/mdx/Callout.astro';
+import CodeBlock from '~hive/components/mdx/CodeBlock.astro';
+import Image from '~hive/components/mdx/Image.astro';
+import PackageManagerTabs from '~hive/components/mdx/PackageManagerTabs.astro';
+import PackageManagerTab from '~hive/components/mdx/Tab.astro';
+import Table from '~hive/components/mdx/Table.astro';
+import ProductUpdateLayout from '~hive/layouts/ProductUpdateLayout.astro';
+import { getHeadingHtmlBySlug } from '~hive/lib/docs-markdown';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
-import Callout from '../../../../hive/components/mdx/Callout.astro';
-import CodeBlock from '../../../../hive/components/mdx/CodeBlock.astro';
-import Image from '../../../../hive/components/mdx/Image.astro';
-import PackageManagerTabs from '../../../../hive/components/mdx/PackageManagerTabs.astro';
-import PackageManagerTab from '../../../../hive/components/mdx/Tab.astro';
-import Table from '../../../../hive/components/mdx/Table.astro';
-import ProductUpdateLayout from '../../../../hive/layouts/ProductUpdateLayout.astro';
-import { getHeadingHtmlBySlug } from '../../../../hive/lib/docs-markdown';
 
 type ProductUpdate = CollectionEntry<'productUpdates'>;
 

--- a/website/src/pages/graphql/hive/product-updates/index.astro
+++ b/website/src/pages/graphql/hive/product-updates/index.astro
@@ -1,11 +1,11 @@
 ---
+import BaseHead from '~hive/components/BaseHead.astro';
+import SiteFooter from '~hive/components/SiteFooter.astro';
+import SiteNavigation from '~hive/components/SiteNavigation.astro';
+import ThemeInit from '~hive/components/ThemeInit.astro';
+import { withBase } from '~hive/lib/base-path';
 import { getCollection } from 'astro:content';
-import BaseHead from '../../../../hive/components/BaseHead.astro';
-import SiteFooter from '../../../../hive/components/SiteFooter.astro';
-import SiteNavigation from '../../../../hive/components/SiteNavigation.astro';
-import ThemeInit from '../../../../hive/components/ThemeInit.astro';
-import { withBase } from '../../../../hive/lib/base-path';
-import '../../../../hive/styles/global.css';
+import '~hive/styles/global.css';
 
 function dateString(value: unknown) {
   return value instanceof Date ? value.toISOString().slice(0, 10) : String(value);

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
-
-const SITE = 'https://the-guild.dev';
+import { SITE_ORIGIN as SITE } from '../hive/lib/base-path';
 
 // Root-level llms.txt: an index of The Guild's ecosystem for agents and
 // crawlers. The Hive docs ship their own, much deeper one under

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "astro/tsconfigs/strict",
-  "exclude": ["src/hive/design-system"]
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~hive/*": ["./src/hive/*"]
+    }
+  }
 }


### PR DESCRIPTION
Fifth PR of the code-review series (stacked on #1933).

**Constants** — `https://the-guild.dev` and `/graphql/hive` were declared independently 9 times across components, endpoints, lib and postbuild scripts. `src/hive/lib/base-path.ts` now exports `SITE_ORIGIN` / `basePath` / `HIVE_SITE_URL` and everything imports it — including the Node-run scripts, which resolve the `.ts` source directly under type stripping.

**Path aliases** — `~hive/*` in tsconfig (honored natively by Astro/Vite), with **130 deep relative imports** (`../../../../hive/…`) across the hive pages tree codemodded to it, `import.meta.glob` patterns included. Named `~hive` to avoid colliding with the `@hive/design-system` MDX-shim aliases.

**Collection schemas** — the four Hive collections (438 MDX files) had no frontmatter validation, forcing 23 `as`-casts in consumers. Schemas now encode exactly what those casts assumed (unknown-key passthrough, unions for the legacy string-vs-array/string-vs-date variance). Everything validates on the first build; future frontmatter typos fail the build instead of rendering `undefined`.

**Byte-verified**: output identical to the base branch except the 10 documented build-nondeterministic pages. astro check 0/0, sitemap verifier, 595-page sweep, tests, lint, prettier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added structured frontmatter validation for Hive documentation, product updates, case studies, and blog content while preserving legacy fields.
* **SEO & Site Metadata**
  * Centralized Hive site URLs and base-path configuration for consistent metadata, feeds, sitemaps, redirects, and SEO checks.
* **Maintenance**
  * Standardized Hive page imports and TypeScript path configuration, with no changes to page behavior or rendered content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->