### PR TITLE
Serve /graphql/codegen from the unified site (router mapping removal)

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -24,13 +24,6 @@ export const jsonConfig = {
   } satisfies RewriteRecord,
   mappings: {
     // Rewrites
-    '/graphql/codegen': {
-      rewrite: 'graphql-code-generator.pages.dev',
-      crisp: {
-        segments: ['codegen'],
-      },
-      sitemap: true,
-    },
     '/graphql/yoga-server': {
       rewrite: 'graphql-yoga.pages.dev',
       crisp: { segments: ['yoga'] },


### PR DESCRIPTION
Follow-up to #1939 — removes the router rewrite of `/graphql/codegen` to `graphql-code-generator.pages.dev`, letting the fallback (this repo's Pages deployment) serve the ported Codegen site. The worker's sitemap injection for codegen also stops applying; the static sitemapindex added in #1939 covers it.

**⚠️ Merge only after #1939 is merged AND its Pages deploy has finished** — the router deploys instantly on merge while Pages takes the build duration, and removing the mapping early would 404 the whole codegen site for that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `/graphql/codegen` rewrite route from website routing configuration.
  * Other routing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->