### PR TITLE
Update docs for usage reporting

### DIFF
--- a/website/src/hive/documentation/content/docs/api-reference/usage-report-v2.schema.json
+++ b/website/src/hive/documentation/content/docs/api-reference/usage-report-v2.schema.json
@@ -63,6 +63,80 @@
               "errorsTotal": {
                 "type": "integer",
                 "minimum": 0
+              },
+              "fetches": {
+                "type": ["array", "null"],
+                "items": {
+                  "title": "OperationSubRequest",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "duration": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "status": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "fields": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coordinate": {
+                            "type": "string"
+                          },
+                          "code": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["coordinate"]
+                      }
+                    },
+                    "subgraph": {
+                      "type": "string"
+                    },
+                    "paths": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": ["ROOT", "ENTITY"]
+                    }
+                  },
+                  "required": [
+                    "start",
+                    "duration",
+                    "status",
+                    "fields",
+                    "subgraph",
+                    "paths",
+                    "type"
+                  ]
+                }
               }
             },
             "required": ["ok", "duration", "errorsTotal"]
@@ -110,6 +184,11 @@
           },
           "operationMapKey": {
             "type": "string"
+          },
+          "persistedDocumentHash": {
+            "type": "string",
+            "title": "PersistedDocumentHash",
+            "pattern": "^[a-zA-Z0-9_-]{1,64}~[a-zA-Z0-9._-]{1,64}~([A-Za-z]|[0-9]|_){1,128}$"
           },
           "metadata": {
             "title": "Metadata",

--- a/website/src/hive/documentation/content/docs/api-reference/usage-reports.mdx
+++ b/website/src/hive/documentation/content/docs/api-reference/usage-reports.mdx
@@ -34,11 +34,13 @@ reporting permissions. [Learn how to create an access token](/docs/schema-regist
 ```typescript
 export interface Report {
   size: number;
-  map: {
-    [k: string]: OperationMapRecord;
-  };
+  map: OperationMap;
   operations?: RequestOperation[];
   subscriptionOperations?: SubscriptionOperation[];
+}
+
+export interface OperationMap {
+  [key: string]: OperationMapRecord;
 }
 
 export interface OperationMapRecord {
@@ -51,7 +53,13 @@ export interface OperationMapRecord {
 }
 
 export interface RequestOperation {
+  /**
+   * milliseconds elapsed since January 1, 1970, UTC. must be within retention period of use plan (free/Pro/enterprise)
+   */
   timestamp: number;
+  /**
+   * Used in the Report.map to lookup operation metadata
+   */
   operationMapKey: string;
   execution: Execution;
   metadata?: Metadata;
@@ -60,13 +68,34 @@ export interface RequestOperation {
 
 export interface Execution {
   ok: boolean;
+  /**
+   * in nanoseconds
+   */
   duration: number;
   errorsTotal: number;
+  fetches?: OperationSubgraphRequest[] | null;
+}
+
+export interface OperationSubgraphRequest {
+  start: number;
+  duration: number;
+  status: number;
+  fields: { [coordinate: string]: number };
+  errors?: SubgraphError[];
+  subgraph: string;
+  paths: string | string[];
+  type: "ROOT" | "ENTITY";
+}
+
+export interface SubgraphError {
+  coordinate: string;
+  code?: string;
 }
 
 export interface SubscriptionOperation {
   timestamp: number;
   operationMapKey: string;
+  persistedDocumentHash?: string;
   metadata?: Metadata;
 }
 
@@ -98,12 +127,12 @@ export interface Metadata {
     "c3b6d9b0": {
       "operationName": "me",
       "operation": "query me { me { id name } }",
-      "fields": ["Query", "Query.me", "User", "User.id", "User.name"],
+      "fields": ["Query", "Query.me", "User", "User.id", "User.name"]
     },
     "762a45e3": {
       "operationName": "users",
       "operation": "query users { users { id } }",
-      "fields": ["Query", "Query.users", "User", "User.id"],
+      "fields": ["Query", "Query.users", "User", "User.id"]
     },
     "12f3712a": {
       "operationName": "liveCoordinates",
@@ -114,69 +143,116 @@ export interface Metadata {
         "User",
         "Location",
         "Location.x",
-        "Location.y",
-      ],
-    },
+        "Location.y"
+      ]
+    }
   },
   "operations": [
     {
-      "operationMapKey": "c3b6d9b0", // points to the 'me' query
-      "timestamp": 1663158676535, // milliseconds elapsed since January 1, 1970, UTC. must be within retention period of use plan (free/Pro/enterprise)
+      "operationMapKey": "c3b6d9b0",
+      "timestamp": 1663158676535,
       "execution": {
         "ok": true,
-        "duration": 150000000, // 150ms in nanoseconds
+        "duration": 150000000,
         "errorsTotal": 0,
+        "fetches": [
+          {
+            "start": 1200000,
+            "duration": 142000000,
+            "status": 200,
+            "subgraph": "users-subgraph",
+            "type": "ROOT",
+            "paths": "Query",
+            "fields": {
+              "Query": 1,
+              "Query.me": 1,
+              "User": 1,
+              "User.id": 1,
+              "User.name": 1,
+              "ID": 1
+              "String": 1
+            }
+          }
+        ]
       },
       "metadata": {
         "client": {
           "name": "demo",
-          "version": "0.0.1",
-        },
+          "version": "0.0.1"
+        }
       },
+      "persistedDocumentHash": "sha256~demo-app~a1b2c3d4e5f6g7h8i9j0"
     },
     {
-      "operationMapKey": "c3b6d9b0", // points to the 'me' query
+      "operationMapKey": "c3b6d9b0",
       "timestamp": 1663158676589,
       "execution": {
-        "ok": false, // failed operation
-        "duration": 150000000, // 150ms in nanoseconds
-        "errorsTotal": 1, // 1 GraphQL error
+        "ok": false,
+        "duration": 150000000,
+        "errorsTotal": 1,
+        "fetches": [
+          {
+            "start": 800000,
+            "duration": 148000000,
+            "status": 200,
+            "subgraph": "users-subgraph",
+            "type": "ROOT",
+            "paths": ["Query"],
+            "fields": {
+              "Query": 1,
+              "Query.me": 1,
+              "User": 1,
+              "User.id": 1
+              "User.name": 1,
+              "ID": 1
+            },
+            "errors": [
+              {
+                "coordinate": "User.name",
+                "code": "UNAUTHENTICATED"
+              }
+            ]
+          }
+        ]
       },
       "metadata": {
         "client": {
           "name": "demo",
-          "version": "0.0.1",
-        },
+          "version": "0.0.1"
+        }
       },
+      "persistedDocumentHash": "sha256~demo-app~a1b2c3d4e5f6g7h8i9j0"
     },
     {
-      "operationMapKey": "762a45e3", // points to the 'users' query
+      "operationMapKey": "762a45e3",
       "timestamp": 1663158676589,
       "execution": {
         "ok": true,
-        "duration": 150000000, // 150ms in nanoseconds
+        "duration": 150000000,
         "errorsTotal": 0,
+        "fetches": null
       },
       "metadata": {
         "client": {
           "name": "demo",
-          "version": "0.0.1",
-        },
-      },
-    },
+          "version": "0.0.1"
+        }
+      }
+    }
   ],
   "subscriptionOperations": [
     {
-      "operationMapKey": "12f3712a", // points to the 'users' query
+      "operationMapKey": "12f3712a",
       "timestamp": 1663158676589,
       "metadata": {
         "client": {
           "name": "demo",
-          "version": "0.0.1",
-        },
+          "version": "0.0.1"
+        }
       },
-    },
-  ],
+      "persistedDocumentHash": "sha256~demo-app~z9y8x7w6v5u4t3s2r1q0"
+    }
+  ]
 }
 ```
 

--- a/website/src/hive/documentation/content/docs/gateway/usage-reporting.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/usage-reporting.mdx
@@ -101,6 +101,35 @@ If you want to control the usage reporting to the Hive Console like `selfHosting
 please look at the Hive Client documentation to learn more about other options.
 [See more in Hive Client reference](/docs/api-reference/client#configuration)
 
+## Experimental: gateway-plugin-console-sdk
+
+If using Hive Gateway and you want to track the executions for your schema coordinates, then you may enable a new experimental feature, "Field Level Metrics".
+This new feature requires a bit more processing power to parse through your execution result, so scale accordingly, but it allows tracking the exact number of times each schema coordinate has been executed. It also tracks GraphQLErrors by coordinate along with any error codes (from the error's `extensions.code` field). This means much deeper and more accurate insights into how your API is performing.
+
+```ts title="gateway.config.ts"
+import { defineConfig } from "@graphql-hive/gateway";
+import { useHive } from "@graphql-hive/gateway-plugin-console-sdk";
+
+export const gatewayConfig = defineConfig({
+  // Disable default reporter and usage provider, "@graphql-hive/yoga"
+  reporting: {
+    enabled: false,
+    type: "hive",
+    usage: false,
+  },
+  plugins: (ctx) => [
+    // Enable gateway plugin as the hive reporter and usage tracker
+    useHive({
+      token: "<token>",
+      usage: {
+        fieldLevelMetricsEnabled: true,
+      },
+      enabled: true,
+    }),
+  ],
+});
+```
+
 </Tabs.Tab>
 
 {/* Apollo GraphOS */}


### PR DESCRIPTION
Moved from https://github.com/graphql-hive/docs/pull/127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated usage report documentation and schemas to describe subgraph fetch telemetry, including timing, status, fields, paths, request type, and errors.
  - Documented persisted document hashes for subscription operations.
  - Clarified operation-map structures, usage report timestamps, and references between operations and report data.
  - Updated examples to reflect subgraph errors, fetch details, persisted hashes, and the revised report structure.
  - Added experimental gateway guidance for enabling subgraph field-level metrics and tracking schema-coordinate errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->