### PR TITLE
Fix Hive redirects and links that landed on 404 pages

### DIFF
--- a/website/scripts/hive/generate-redirects.ts
+++ b/website/scripts/hive/generate-redirects.ts
@@ -8,7 +8,7 @@ import { routeRules } from '../../src/hive/documentation/redirects.ts';
  * redirects.ts stay un-prefixed (they predate the merge and read naturally).
  */
 import { basePath as PREFIX } from '../../src/hive/lib/base-path.ts';
-import { DIST } from '../lib/build-output.ts';
+import { DIST, resolvesInDist } from '../lib/build-output.ts';
 
 const outputDirectory = DIST;
 const outputFile = `${DIST}/_redirects`;
@@ -78,6 +78,24 @@ const redirects = [
   }),
   ...astroOnlyRedirects,
 ].sort((a, b) => Number(a.source.endsWith('/*')) - Number(b.source.endsWith('/*')));
+
+// A redirect that lands on a missing page is a 404 Google reports against us
+// (three catch-alls did exactly that in 2026-09). Every fixed Hive
+// destination must be a page in the build; splat destinations depend on the
+// request path and cannot be checked statically.
+const deadDestinations = redirects
+  .map(({ destination }) => destination.split('#')[0]!)
+  .filter(
+    destination =>
+      destination.startsWith(`${PREFIX}/`) &&
+      !destination.includes(':splat') &&
+      !resolvesInDist(destination),
+  );
+if (deadDestinations.length > 0) {
+  throw new Error(
+    `Redirect destinations that are not pages in the build:\n${[...new Set(deadDestinations)].map(d => `  ${d}`).join('\n')}`,
+  );
+}
 
 const MARKER =
   '# Generated from website/src/hive/documentation/redirects.ts. Do not edit manually.';

--- a/website/scripts/lib/build-output.ts
+++ b/website/scripts/lib/build-output.ts
@@ -4,7 +4,7 @@
  * scripts re-deriving paths, parsing sitemaps and reading _redirects in
  * subtly different ways.
  */
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { basePath, SITE_ORIGIN } from '../../src/hive/lib/base-path.ts';
 
@@ -21,7 +21,13 @@ export function publicPath(relativePath: string): string {
   return `/${relativePath.replace(/\/index\.html$/, '').replace(/\.html$/, '')}`;
 }
 
-/** Whether an internal path resolves to a file in dist. */
+const isFile = (path: string) => existsSync(path) && statSync(path).isFile();
+
+/**
+ * Whether an internal path resolves to a file in dist. A bare directory does
+ * not count: Pages serves nothing there, so a redirect or link that lands on
+ * one is a 404.
+ */
 export function resolvesInDist(pathname: string): boolean {
   const decoded = decodeURI(pathname);
   return [
@@ -29,7 +35,7 @@ export function resolvesInDist(pathname: string): boolean {
     `${DIST}${decoded}.html`,
     `${DIST}${decoded}/index.html`,
     ...(decoded === '/' ? [`${DIST}/index.html`] : []),
-  ].some(candidate => existsSync(candidate));
+  ].some(isFile);
 }
 
 /** Every <loc> pathname across the generated sitemaps. */

--- a/website/src/hive/components/blog/BlogTagChip.astro
+++ b/website/src/hive/components/blog/BlogTagChip.astro
@@ -37,7 +37,7 @@ const chipClasses = [
         'rounded-full px-3 py-1 text-sm text-white outline-hidden focus-visible:ring-3',
         chipClasses,
       ]}
-      href={withBase(`/blog/tag/${tag}`)}
+      href={withBase(`/blog/tag/${encodeURIComponent(tag)}`)}
     >
       {prettyPrintTag(tag)}
     </a>

--- a/website/src/hive/components/blog/CategoryFilterLink.astro
+++ b/website/src/hive/components/blog/CategoryFilterLink.astro
@@ -18,7 +18,7 @@ const isActive = currentCategory === category;
       ? 'text-green-1000 bg-green-200 hover:bg-transparent! hover:text-green-800 dark:bg-neutral-800 dark:text-white dark:hover:text-white/80'
       : 'hover:bg-beige-100 hover:text-green-1000 text-green-800 dark:text-white/80 dark:hover:bg-neutral-800 dark:hover:text-white',
   ]}
-  href={withBase(category ? `/blog/tag/${category}` : '/blog')}
+  href={withBase(category ? `/blog/tag/${encodeURIComponent(category)}` : '/blog')}
 >
   {prettyPrintTag(category || 'All')}
 </a>

--- a/website/src/hive/documentation/content/blog/announcing-free-single-sign-on-for-graphql-hive/index.mdx
+++ b/website/src/hive/documentation/content/blog/announcing-free-single-sign-on-for-graphql-hive/index.mdx
@@ -39,5 +39,5 @@ helped us a lot with questions and feedback on shipping this feature. Hive Conso
 [fully open source](https://github.com/graphql-hive/console) and also uses the SuperTokens Open
 Source project for user authentication.
 
-- [Get started with adding OAuth OIDC SSO to your Hive Console organization](https://the-guild.dev/graphql/hive/docs/management/sso-oidc-provider)
-- [Get started with with custom OIDC providers for self-hosted Hive](https://the-guild.dev/graphql/hive/docs/self-hosting/oidc-login)
+- [Get started with adding OAuth OIDC SSO to your Hive Console organization](/docs/schema-registry/management/sso-oidc-provider)
+- [Get started with with custom OIDC providers for self-hosted Hive](/docs/schema-registry/self-hosting/oidc-login)

--- a/website/src/hive/documentation/content/blog/announcing-self-hosted-graphql-hive/index.mdx
+++ b/website/src/hive/documentation/content/blog/announcing-self-hosted-graphql-hive/index.mdx
@@ -35,4 +35,4 @@ Today, we are happy to announce that we have reached this milestone and spinning
 Hive Console instance is as easy as running a single command! All you need is `docker` and
 `docker-compose` installed on your machine.
 
-[Head over to our Hive Console documentation for getting started!](https://the-guild.dev/graphql/hive/docs/self-hosting/get-started)
+[Head over to our Hive Console documentation for getting started!](/docs/schema-registry/self-hosting/get-started)

--- a/website/src/hive/documentation/content/blog/graphql-deep-dive-6/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-deep-dive-6/index.mdx
@@ -204,7 +204,7 @@ are a lot of interesting things
 [you can do in your CI/CD pipeline](https://the-guild.dev/graphql/hive/docs/other-integrations/ci-cd)
 like [linting your schema](https://the-guild.dev/graphql/hive/docs/schema-registry/schema-policy)
 and
-[validating it, getting the list of breaking changes](https://the-guild.dev/graphql/hive/docs/get-started/apollo-federation#schema-checks),
+[validating it, getting the list of breaking changes](/docs/schema-registry/get-started/apollo-federation#schema-checks),
 pushing it to the [registry](https://the-guild.dev/graphql/hive/docs/schema-registry), running
 automated tests, sending notifications to relevant people in your team as needed and so on saving a
 lot of time and also providing a high degree of reliability and confidence to what you ship to

--- a/website/src/hive/documentation/content/blog/graphql-mesh-v1-hive-gateway-v1/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-mesh-v1-hive-gateway-v1/index.mdx
@@ -51,7 +51,7 @@ license is required**!
 - [Caching](https://the-guild.dev/graphql/hive/docs/gateway/other-features/performance)
 - [Rate Limiting](https://the-guild.dev/graphql/hive/docs/gateway/other-features/security/rate-limiting)
 - [Persisted Documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents)
-- [Query Complexity Analysis](https://the-guild.dev/graphql/hive/docs/gateway/other-features/security/cost-limit)
+- [Query Complexity Analysis](/docs/gateway/other-features/security/demand-control)
 - And more…
 
 We listened to the feedback of the companies using Version 0 of GraphQL Mesh, and decided that Hive

--- a/website/src/hive/documentation/content/blog/stellate-acquisition/index.mdx
+++ b/website/src/hive/documentation/content/blog/stellate-acquisition/index.mdx
@@ -57,7 +57,7 @@ want to learn about your current GraphQL experience and how the existing solutio
 for you.
 
 To everyone else, try Stellate today,
-[try Hive today](https://the-guild.dev/graphql/hive/docs/get-started/first-steps) and let us know
-what you wish the future of GraphQL to look like.
+[try Hive today](/docs/schema-registry/get-started/first-steps) and let us know what you wish the
+future of GraphQL to look like.
 
 See you all at [GraphQL Conf](https://graphql.org/conf/2024/)!

--- a/website/src/hive/documentation/redirects.ts
+++ b/website/src/hive/documentation/redirects.ts
@@ -60,22 +60,57 @@ export const routeRules: Record<string, RouteRule> = {
   // Schema registry link specifications
   '/docs/schema-registry/link-specifications': redirect('/docs/api-reference/link-specifications'),
 
-  // Management paths → schema-registry/management
-  '/docs/management/**': redirect('/docs/schema-registry/management'),
+  // Management paths → schema-registry/management (no index page there, so
+  // the catch-all lands on the first page and known sub-pages map 1:1)
+  '/docs/management/**': redirect('/docs/schema-registry/management/organizations'),
+  '/docs/management/access-tokens': redirect('/docs/schema-registry/management/access-tokens'),
+  '/docs/management/audit-logs': redirect('/docs/schema-registry/management/audit-logs'),
+  '/docs/management/members-roles-permissions': redirect(
+    '/docs/schema-registry/management/members-roles-permissions',
+  ),
+  '/docs/management/organizations': redirect('/docs/schema-registry/management/organizations'),
+  '/docs/management/projects': redirect('/docs/schema-registry/management/projects'),
+  '/docs/management/scim-provisioning': redirect(
+    '/docs/schema-registry/management/scim-provisioning',
+  ),
+  '/docs/management/targets': redirect('/docs/schema-registry/management/targets'),
   '/docs/management/contracts': redirect('/docs/schema-registry/contracts'),
   '/docs/management/external-schema-composition': redirect(
     '/docs/schema-registry/external-schema-composition',
   ),
 
-  // Get started paths
-  '/docs/get-started/**': redirect('/docs/schema-registry/get-started'),
+  // Get started paths (no index page there either)
+  '/docs/get-started/**': redirect('/docs/schema-registry/get-started/first-steps'),
+  '/docs/get-started/first-steps': redirect('/docs/schema-registry/get-started/first-steps'),
+  '/docs/get-started/apollo-federation': redirect(
+    '/docs/schema-registry/get-started/apollo-federation',
+  ),
+  '/docs/get-started/schema-stitching': redirect(
+    '/docs/schema-registry/get-started/schema-stitching',
+  ),
+  '/docs/get-started/single-project': redirect('/docs/schema-registry/get-started/single-project'),
   '/docs/get-started/organizations': redirect('/docs/schema-registry/management/organizations'),
   '/docs/get-started/projects': redirect('/docs/schema-registry/management/projects'),
   '/docs/get-started/targets': redirect('/docs/schema-registry/management/targets'),
 
   // Self-hosting
   '/docs/self-hosting': redirect('/docs/schema-registry/self-hosting/get-started'),
-  '/docs/self-hosting/**': redirect('/docs/schema-registry/self-hosting'),
+  '/docs/self-hosting/**': redirect('/docs/schema-registry/self-hosting/get-started'),
+  '/docs/self-hosting/get-started': redirect('/docs/schema-registry/self-hosting/get-started'),
+  '/docs/self-hosting/oidc-login': redirect('/docs/schema-registry/self-hosting/oidc-login'),
+  '/docs/self-hosting/cdn-artifacts': redirect('/docs/schema-registry/self-hosting/cdn-artifacts'),
+  '/docs/self-hosting/changelog': redirect('/docs/schema-registry/self-hosting/changelog'),
+  '/docs/self-hosting/client-and-cli-configuration': redirect(
+    '/docs/schema-registry/self-hosting/client-and-cli-configuration',
+  ),
+  '/docs/self-hosting/external-composition': redirect(
+    '/docs/schema-registry/self-hosting/external-composition',
+  ),
+  '/docs/self-hosting/s3-provider': redirect('/docs/schema-registry/self-hosting/s3-provider'),
+  '/docs/self-hosting/telemetry': redirect('/docs/schema-registry/self-hosting/telemetry'),
+  '/docs/self-hosting/troubleshooting': redirect(
+    '/docs/schema-registry/self-hosting/troubleshooting',
+  ),
   '/docs/self-hosting/apollo-federation-2': redirect(
     '/docs/schema-registry/self-hosting/external-composition',
   ),


### PR DESCRIPTION
## Summary

A Search Console "Not found (404)" report prompted a crawl of every sitemap URL and every internal link on the-guild.dev. All 2,125 sitemap URLs return 200; the 404s come from links between pages. Most originate in other product sites (root-relative links missing their mount prefix). This PR fixes the parts that live here.

- Three Hive catch-all redirects (`/docs/get-started/*`, `/docs/self-hosting/*`, `/docs/management/*`) sent old URLs to section folders with no index page. They now land on real pages, and each known old sub-page maps to its renamed counterpart.
- One blog post linked a Gateway `cost-limit` page that no longer exists; it now points at `demand-control`. Five posts still used the old doc URLs and now link the new pages directly.
- Blog tag links containing spaces are URL-encoded.
- `generate-redirects.ts` now fails the build when a fixed redirect destination is not a page in `dist`. `resolvesInDist` no longer counts a bare directory as a page, which is how the dead catch-alls slipped past the existing checks.

## Verification

- Full `astro build` plus the Hive postbuild scripts pass; `verify-base-path` is clean.
- The new guard was confirmed to fail against the previous `redirects.ts` and pass against this one.
- Built HTML contains the encoded tag hrefs and the corrected blog link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Blog tag and category links now correctly handle special characters in names.
  - Redirects are validated against available documentation pages, helping prevent broken navigation.
  - Documentation redirects now route management, getting-started, and self-hosting pages to the appropriate destinations.

- **Documentation**
  - Updated links across blog content to current documentation locations.
  - Corrected links for SSO, self-hosting, schema checks, query complexity analysis, and initial setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->