### PR TITLE
Make case study and blog prose readable in dark mode

### DIFF
--- a/website/src/hive/layouts/BlogPostLayout.astro
+++ b/website/src/hive/layouts/BlogPostLayout.astro
@@ -148,6 +148,35 @@ const pageTitle = title.includes('|') ? title : `${title} | Hive`;
     line-height: 1.75;
   }
 
+  /* Dark theme: the rules below hardcode the light palette, which
+     dark:prose-invert on the article cannot override. */
+  .dark [data-blog-prose] {
+    color: var(--color-neutral-200);
+  }
+
+  .dark [data-blog-prose] :is(h2, h3, h4, h5, h6):not(:where(.not-prose *)),
+  .dark [data-blog-prose] div:has(> blockquote) blockquote {
+    color: var(--color-white);
+  }
+
+  .dark [data-blog-prose] blockquote,
+  .dark [data-blog-prose] th,
+  .dark [data-blog-prose] td {
+    border-color: var(--color-neutral-700);
+  }
+
+  .dark [data-blog-prose] div:has(> blockquote) {
+    background: var(--color-neutral-800);
+  }
+
+  .dark [data-blog-prose] a:not(:where(.not-prose, .not-prose *)) {
+    text-decoration-color: var(--color-blue-300);
+  }
+
+  .dark [data-blog-prose] a:not(:where(.not-prose, .not-prose *)):hover {
+    color: var(--color-blue-300);
+  }
+
   [data-blog-prose] > :is(h2, h3, h4, h5, h6, p, ol, ul, figure, hr, iframe):not(.hive-bleed) {
     max-width: var(--article-max-width);
     margin-inline: auto;

--- a/website/src/hive/layouts/CaseStudyLayout.astro
+++ b/website/src/hive/layouts/CaseStudyLayout.astro
@@ -274,6 +274,34 @@ const pageTitle = `${title} | Hive`;
     line-height: 1.75;
   }
 
+  /* Dark theme: the rules below hardcode the light palette, which
+     dark:prose-invert on the article cannot override. */
+  .dark [data-case-study-prose] {
+    color: var(--color-neutral-200);
+  }
+
+  .dark [data-case-study-prose] :is(h2, h3, h4, h5, h6):not(:where(.not-prose *)),
+  .dark [data-case-study-prose] div:has(> blockquote) blockquote {
+    color: var(--color-white);
+  }
+
+  .dark [data-case-study-prose] blockquote,
+  .dark [data-case-study-prose] pre {
+    border-color: var(--color-neutral-700);
+  }
+
+  .dark [data-case-study-prose] div:has(> blockquote) {
+    background: var(--color-neutral-800);
+  }
+
+  .dark [data-case-study-prose] a:not(:where(.not-prose, .not-prose *)) {
+    text-decoration-color: var(--color-blue-300);
+  }
+
+  .dark [data-case-study-prose] a:not(:where(.not-prose, .not-prose *)):hover {
+    color: var(--color-blue-300);
+  }
+
   [data-case-study-prose]
     > :is(h2, h3, h4, h5, h6, p, ol, ul, figure, hr, iframe):not(.hive-bleed) {
     max-width: var(--article-max-width);


### PR DESCRIPTION
## Summary

On https://the-guild.dev/graphql/hive/case-studies/reverb in dark mode the article body, headings and lists render in the light-mode green on the near-black background. The Hive blog posts have the same problem.

Both layouts' global stylesheets hardcode the light palette on the article (green text and headings, beige quote card and borders, light-mode link blue), which overrides `dark:prose-invert`. This adds `.dark` overrides using the site's existing dark tokens: neutral-200 body text, white headings and quote text, neutral-800 quote cards, neutral-700 borders, blue-300 links. Light mode is unchanged.

## Verification

Computed prose color checked in both themes for a case study and a blog post; screenshots of the Reverb case study (intro, pull-quote card, results list) and a blog post in dark mode read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dark-theme readability across blog posts and case studies.
  - Updated text, headings, quotes, code blocks, borders, backgrounds, and links for better contrast and visibility in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->