### PR TITLE
Add llms.txt and llms-full.txt for the Codegen docs

### DIFF
--- a/website/src/codegen/lib/llms.test.ts
+++ b/website/src/codegen/lib/llms.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import type { DocsNavNode } from '../../docs/nav';
+import { getCodegenLlmsText } from './llms';
+
+describe('getCodegenLlmsText', () => {
+  test('lists docs and plugins in sidebar order with Markdown links', () => {
+    const docs = [
+      { body: '# Intro', data: { description: 'Start here' }, id: 'getting-started/index.mdx' },
+      { body: 'Guide', data: {}, id: 'guides/react-vue.mdx' },
+    ];
+    const plugins = [
+      {
+        body: 'Resolvers prose',
+        data: { description: 'Typed resolvers' },
+        id: 'typescript/typescript-resolvers.mdx',
+      },
+      { body: '', data: {}, id: 'other/add.mdx' },
+    ];
+    const docsNav: DocsNavNode[] = [
+      { href: '/docs/getting-started', title: 'Getting Started', type: 'page' },
+      {
+        children: [{ href: '/docs/guides/react-vue', title: 'React / Vue', type: 'page' }],
+        title: 'Guides',
+        type: 'folder',
+      },
+    ];
+    const pluginsNav: DocsNavNode[] = [
+      {
+        children: [
+          { href: '/plugins/typescript/typescript-resolvers', title: 'resolvers', type: 'page' },
+        ],
+        title: 'TypeScript',
+        type: 'folder',
+      },
+      {
+        children: [{ href: '/plugins/other/add', title: 'add', type: 'page' }],
+        title: 'Other',
+        type: 'folder',
+      },
+    ];
+
+    const output = getCodegenLlmsText({ docs, docsNav, plugins, pluginsNav });
+
+    expect(output.startsWith('# GraphQL Code Generator\n')).toBe(true);
+    expect(output).toContain(
+      '- [Getting Started](https://the-guild.dev/graphql/codegen/docs/getting-started.md): Start here',
+    );
+    expect(output).toContain(
+      '- [React / Vue](https://the-guild.dev/graphql/codegen/docs/guides/react-vue.md)',
+    );
+    expect(output).toContain(
+      '- [resolvers](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-resolvers.md): Typed resolvers',
+    );
+    // No prose of its own → no Markdown rendition; link the page.
+    expect(output).toContain('- [add](https://the-guild.dev/graphql/codegen/plugins/other/add)\n');
+    expect(output.indexOf('## Documentation')).toBeLessThan(
+      output.indexOf('## Plugins and presets'),
+    );
+  });
+});

--- a/website/src/codegen/lib/llms.ts
+++ b/website/src/codegen/lib/llms.ts
@@ -1,0 +1,58 @@
+import type { DocsNavNode, DocsNavPage } from '../../docs/nav';
+import { CODEGEN_SITE_URL as SITE_URL } from './base-path';
+
+interface LlmsEntry {
+  body?: string;
+  data: { description?: string };
+  id: string;
+}
+
+function flattenPages(node: DocsNavNode): DocsNavPage[] {
+  if (node.type === 'page') return [node];
+  const ownPage = node.href ? [{ href: node.href, title: node.title, type: 'page' as const }] : [];
+  return [...ownPage, ...node.children.flatMap(flattenPages)];
+}
+
+/** Mount-relative href of a content entry: /docs/<slug> or /plugins/<slug>. */
+export function entryHref(hrefBase: string, entry: { id: string }) {
+  const slug = entry.id.replace(/\.(md|mdx)$/, '').replace(/(^|\/)index$/, '');
+  return `${hrefBase}${slug ? `/${slug}` : ''}`;
+}
+
+/**
+ * The llms.txt index for the Codegen docs: every documentation page and
+ * plugin page in sidebar order, linked to its Markdown rendition. Plugin
+ * pages without prose of their own have no Markdown; they link to the page.
+ */
+export function getCodegenLlmsText(input: {
+  docs: LlmsEntry[];
+  docsNav: DocsNavNode[];
+  plugins: LlmsEntry[];
+  pluginsNav: DocsNavNode[];
+}) {
+  const byHref = new Map<string, LlmsEntry>([
+    ...input.docs.map(entry => [entryHref('/docs', entry), entry] as const),
+    ...input.plugins.map(entry => [entryHref('/plugins', entry), entry] as const),
+  ]);
+  const link = (page: DocsNavPage) => {
+    const entry = byHref.get(page.href);
+    const hasMarkdown = (entry?.body ?? '').trim().length > 0;
+    const description = entry?.data.description ? `: ${entry.data.description}` : '';
+    return `- [${page.title}](${SITE_URL}${page.href}${hasMarkdown ? '.md' : ''})${description}`;
+  };
+  const section = (title: string, nodes: DocsNavNode[]) => [
+    `## ${title}`,
+    '',
+    ...nodes.flatMap(flattenPages).map(link),
+    '',
+  ];
+
+  return [
+    '# GraphQL Code Generator',
+    '',
+    '> Generate typed code from GraphQL schemas and operations: clients, resolvers, SDKs and more, through a plugin ecosystem.',
+    '',
+    ...section('Documentation', input.docsNav),
+    ...section('Plugins and presets', input.pluginsNav),
+  ].join('\n');
+}

--- a/website/src/pages/graphql/codegen/llms-full.txt.ts
+++ b/website/src/pages/graphql/codegen/llms-full.txt.ts
@@ -1,0 +1,40 @@
+import { getDocsMarkdown } from '~hive/lib/docs-markdown';
+import { getCollection } from 'astro:content';
+import { getCodegenDocsNav, getCodegenPluginsNav } from '../../../codegen/lib/docs-nav';
+import { entryHref } from '../../../codegen/lib/llms';
+import type { DocsNavNode } from '../../../docs/nav';
+
+export const prerender = true;
+
+function hrefsInOrder(nodes: DocsNavNode[]): string[] {
+  return nodes.flatMap(node =>
+    node.type === 'page'
+      ? [node.href]
+      : [...(node.href ? [node.href] : []), ...hrefsInOrder(node.children)],
+  );
+}
+
+/**
+ * The whole Codegen documentation as one Markdown file for LLM consumption:
+ * docs pages then plugin pages, in sidebar order, from the same per-page
+ * Markdown that backs the *.md endpoints.
+ */
+export async function GET() {
+  const [docs, plugins, docsNav, pluginsNav] = await Promise.all([
+    getCollection('codegenDocs'),
+    getCollection('codegenPlugins'),
+    getCodegenDocsNav(),
+    getCodegenPluginsNav(),
+  ]);
+  const byHref = new Map<string, { body?: string; id: string }>([
+    ...docs.map(entry => [entryHref('/docs', entry), entry] as const),
+    ...plugins.map(entry => [entryHref('/plugins', entry), entry] as const),
+  ]);
+  const ordered = [...hrefsInOrder(docsNav.tree), ...hrefsInOrder(pluginsNav.tree)]
+    .map(href => byHref.get(href))
+    .filter(entry => entry && (entry.body ?? '').trim().length > 0);
+
+  return new Response(ordered.map(entry => getDocsMarkdown(entry as never)).join('\n\n'), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+}

--- a/website/src/pages/graphql/codegen/llms.txt.ts
+++ b/website/src/pages/graphql/codegen/llms.txt.ts
@@ -1,0 +1,24 @@
+import { getCollection } from 'astro:content';
+import { getCodegenDocsNav, getCodegenPluginsNav } from '../../../codegen/lib/docs-nav';
+import { getCodegenLlmsText } from '../../../codegen/lib/llms';
+
+export const prerender = true;
+
+export async function GET() {
+  const [docs, plugins, docsNav, pluginsNav] = await Promise.all([
+    getCollection('codegenDocs'),
+    getCollection('codegenPlugins'),
+    getCodegenDocsNav(),
+    getCodegenPluginsNav(),
+  ]);
+
+  return new Response(
+    getCodegenLlmsText({
+      docs,
+      docsNav: docsNav.tree,
+      plugins,
+      pluginsNav: pluginsNav.tree,
+    }),
+    { headers: { 'Content-Type': 'text/markdown; charset=utf-8' } },
+  );
+}

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -28,6 +28,8 @@ export const GET: APIRoute = async () => {
 ## Open-source libraries
 
 - [GraphQL Codegen](${SITE}/graphql/codegen): typed code from GraphQL schemas and operations
+- [GraphQL Codegen documentation index for LLMs](${SITE}/graphql/codegen/llms.txt)
+- [Full GraphQL Codegen documentation as one file](${SITE}/graphql/codegen/llms-full.txt)
 - [GraphQL Yoga](${SITE}/graphql/yoga-server): spec-compliant GraphQL server
 - [GraphQL-Tools](${SITE}/graphql/tools): schema building and stitching utilities
 - [GraphQL Mesh](${SITE}/graphql/mesh): compose any API into a graph


### PR DESCRIPTION
## Summary

Codegen already serves per-page Markdown (`/graphql/codegen/docs/*.md`, `/graphql/codegen/plugins/*.md`) but had no `llms.txt` index or `llms-full.txt`, and the shared `BaseHead` already advertises `/graphql/codegen/llms.txt` via `<link rel="alternate" type="text/markdown">`, which 404'd.

- `/graphql/codegen/llms.txt`: every docs and plugin page in sidebar order, linked to its Markdown rendition with the page description. Plugin pages without prose of their own (no `.md` endpoint) link to the page.
- `/graphql/codegen/llms-full.txt`: the same pages concatenated, from the Markdown that backs the `.md` endpoints.
- Root `/llms.txt` links both, matching the Hive entries.

Built from the content collections and the nav tree, the same way the Hive versions are, rather than scraping built HTML.

## Verification

- Unit test for the index builder; `astro check`, ESLint and Prettier clean.
- Dev server: index lists 87 pages (84 with Markdown); every Markdown link resolves with 200; the full file contains the 84 documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an LLM-friendly Markdown index for GraphQL Codegen documentation and plugins.
  - Added a complete documentation export combining Codegen guides and plugin pages.
  - Preserved sidebar navigation order and included available descriptions and Markdown links.
  - Added links to the Codegen documentation and full documentation exports from the root `llms.txt` page.

- **Tests**
  - Added coverage for link generation, ordering, descriptions, and handling of entries without content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->