### PR TITLE
Serve /graphql/yoga-server from the unified site (router mapping removal)

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -24,11 +24,6 @@ export const jsonConfig = {
   } satisfies RewriteRecord,
   mappings: {
     // Rewrites
-    '/graphql/yoga-server': {
-      rewrite: 'graphql-yoga.pages.dev',
-      crisp: { segments: ['yoga'] },
-      sitemap: true,
-    },
     '/graphql/scalars': {
       rewrite: 'graphql-scalars.pages.dev',
       crisp: { segments: ['scalars'] },


### PR DESCRIPTION
Follow-up to #1954 — removes the router rewrite of `/graphql/yoga-server` to `graphql-yoga.pages.dev`, letting the fallback (this repo's Pages deployment) serve the ported Yoga site. The worker's sitemap injection for Yoga also stops applying; the static sitemapindex added in #1954 covers it.

**⚠️ Merge only after #1954 is merged AND its Pages deploy has finished** — the router deploys within a minute of merge while Pages takes the build duration, and removing the mapping early would 404 the whole Yoga site for that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the `/graphql/yoga-server` URL rewrite mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->