### PR TITLE
Stop routing /graphql/mesh to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -24,11 +24,6 @@ export const jsonConfig = {
   } satisfies RewriteRecord,
   mappings: {
     // Rewrites
-    '/graphql/mesh': {
-      rewrite: 'graphql-mesh-ai3.pages.dev',
-      crisp: { segments: ['mesh'] },
-      sitemap: true,
-    },
     '/graphql/shield': {
       redirect: 'https://github.com/maticzav/graphql-shield',
       status: 302,


### PR DESCRIPTION
Removes the `/graphql/mesh` rewrite to `graphql-mesh-ai3.pages.dev` from the website router, so Mesh pages are served by this repo's Pages deployment like Hive, Codegen, and Yoga.

**Merge last**, after the Mesh website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every Mesh URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `/graphql/mesh` route from website rewrites, Crisp navigation, and sitemap listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->