### PR TITLE
blog: consistent watcher, faster server preset, and fixed windows support

### DIFF
--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Consistent Watch Mode and a Faster Server Preset
+title: Consistent Watcher, Happier Windows, and a Faster Server Preset
 authors: eddeee888
 tags: [graphql, graphql-codegen, watch-mode, server-preset, performance]
 date: 2026-09-08
@@ -9,9 +9,9 @@ description:
 ---
 
 Watch mode in [GraphQL Code Generator](https://the-guild.dev/graphql/codegen) is now consistent
-across file tracking, profiling, plugins and presets, and
-[Server Preset](https://github.com/eddeee888/graphql-code-generator-plugins) 0.19 builds on that
-with internal caching to make watch re-runs up to 80% faster.
+across file tracking, profiling, plugins and presets, Windows gets a couple of watch-mode fixes of
+its own, and [Server Preset](https://github.com/eddeee888/graphql-code-generator-plugins) 0.19
+builds on all of that with internal caching to make watch re-runs up to 80% faster.
 
 ## Watch mode is consistent now
 
@@ -35,6 +35,17 @@ The changes shipped across `@graphql-codegen/cli` 7.3.0, 7.3.1 and 7.4.0, in
 [#10928](https://github.com/dotansimha/graphql-code-generator/pull/10928),
 [#10930](https://github.com/dotansimha/graphql-code-generator/pull/10930) and
 [#10936](https://github.com/dotansimha/graphql-code-generator/pull/10936).
+
+## Happier Windows
+
+Windows gets some watch-mode love too: its ignore patterns now always use forward slashes, so
+generated output is correctly ignored instead of being watched and re-triggering builds, and
+loading a schema or documents from a `.js`, `.cjs`, or `.mjs` file no longer crashes with an
+ESM URL-scheme error.
+
+{/* TODO: confirm release status before publishing - #10936 (ignore-glob fix) is merged but not
+    yet in a shipped cli version, and #10935 (ESM import fix) is still an open draft pinning an
+    alpha graphql-tools build; name the release(s) these ship in, or drop these claims */}
 
 ## Server Preset 0.19: up to 80% faster watch re-runs
 

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -20,11 +20,11 @@ Watch mode is the recommended way to work with Codegen in managed workflows like
 Server Preset. But the base CLI's watch-mode support wasn't consistent across plugins and presets,
 and profiling didn't work on every run.
 
-There are fixes and improvements to allow library authors more flexibility to control the output:
+Recent fixes and improvements allow library authors more flexibility to control the output:
 
 - `overwrite.updateExistingFiles` and `overwrite.removeStaleFiles` let a preset control whether its
   regenerated files are updated in place or removed as stale
-- `overwrite` set on a preset-based `generates` entry is no longer silently ignored
+- `overwrite` set on a preset-based `generates` entry now works
 - `contentComparison` lets plugins and presets choose disk vs. cache comparison when deciding
   whether to rewrite a file
 - `--profile --watch` now writes a trace after every rebuild, not just the initial run
@@ -38,7 +38,7 @@ that compares resolver types against your mappers, and the schema parsing that e
 block used to repeat.
 
 Measured on [Hive Console](https://github.com/graphql-hive/console)'s codebase, on re-runs where
-schema types and mappers don't change, generation time dropped by **50 to 80%**.
+schema types and mappers don't change, generation time dropped by **up to 80%**.
 
 ## Fixed Windows
 

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Consistent Watcher, Happier Windows, and a Faster Server Preset
+title: Consistent Watcher, Fixed Windows, and a Faster Server Preset
 authors: eddeee888
 tags: [graphql, graphql-codegen, watch-mode, server-preset, performance]
 date: 2026-09-08
@@ -36,9 +36,9 @@ The changes shipped across `@graphql-codegen/cli` 7.3.0, 7.3.1 and 7.4.0, in
 [#10930](https://github.com/dotansimha/graphql-code-generator/pull/10930) and
 [#10936](https://github.com/dotansimha/graphql-code-generator/pull/10936).
 
-## Happier Windows
+## Fixed Windows
 
-Windows gets some watch-mode love too: its ignore patterns now always use forward slashes, so
+Two Windows-specific watch-mode bugs are fixed: ignore patterns now always use forward slashes, so
 generated output is correctly ignored instead of being watched and re-triggering builds, and
 loading a schema or documents from a `.js`, `.cjs`, or `.mjs` file no longer crashes with an
 ESM URL-scheme error.

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Consistent Watcher, a Faster Server Preset, and Fixed Windows
+title: Consistent Watcher, a Faster Server Preset, and Fixed Windows Support
 authors: eddeee888
 tags: [graphql, graphql-codegen, watch-mode, server-preset, performance]
 date: 2026-09-14
@@ -43,7 +43,7 @@ block used to repeat.
 Measured on [Hive Console](https://github.com/graphql-hive/console)'s codebase, on re-runs where
 schema types and mappers don't change, generation time dropped by **up to 80%**.
 
-## Fixed Windows
+## Fixed Windows Support
 
 We want Codegen to work in any environment seamlessly. Windows support has been lacking, mainly due
 to differences in how Windows handles file paths.

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -50,8 +50,8 @@ to differences in how Windows handles file paths.
 
 That's fixed too:
 
-- Watch mode's ignore patterns now correctly use forward slashes, so generated output is correctly
-  ignored instead of being watched and re-triggering builds
+- Watch mode's ignore patterns now correctly use forward slashes, so generated output is ignored
+  instead of being watched and re-triggering builds
 - Loading a schema or documents from a `.js`, `.cjs`, or `.mjs` file no longer crashes with an ESM
   URL-scheme error
 

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -5,20 +5,23 @@ tags: [graphql, graphql-codegen, watch-mode, server-preset, performance]
 date: 2026-09-08
 description:
   Codegen watch mode is now consistent across file tracking, profiling, plugins and presets,
-  Server Preset 0.19 uses it to cut watch re-runs by up to 80%, and Windows support is improved
+  Server Preset v0.19 uses it to cut watch re-runs by up to 80%, and Windows support is improved
   too.
 ---
 
 Watch mode in [GraphQL Code Generator](https://the-guild.dev/graphql/codegen) is now consistent
 across file tracking, profiling, plugins and presets.
-[Server Preset](https://github.com/eddeee888/graphql-code-generator-plugins) 0.19 builds on that
-with internal caching to make watch re-runs up to 80% faster, and Windows support is improved too.
+[Server Preset v0.19](https://github.com/eddeee888/graphql-code-generator-plugins/releases/tag/%40eddeee888%2Fgcg-typescript-resolver-files%400.19.0)
+builds on that with internal caching to make watch re-runs up to 80% faster, and Windows support is
+improved too.
 
 ## Watch mode is consistent now
 
-Watch mode is the recommended way to work with Codegen in managed workflows like Client Preset and
-Server Preset. But the base CLI's watch-mode support wasn't consistent across plugins and presets,
-and profiling didn't work on every run.
+Watch mode is the recommended way to work with Codegen in managed workflows like
+[Client Preset](https://the-guild.dev/graphql/codegen/plugins/presets/preset-client) and
+[Server Preset](https://the-guild.dev/graphql/codegen/docs/guides/graphql-server-apollo-yoga-with-server-preset).
+But the base CLI's watch-mode support wasn't consistent across plugins and presets, and profiling
+didn't work on every run.
 
 Recent fixes and improvements allow library authors more flexibility to control the output:
 
@@ -29,10 +32,10 @@ Recent fixes and improvements allow library authors more flexibility to control 
   whether to rewrite a file
 - `--profile --watch` now writes a trace after every rebuild, not just the initial run
 
-## Server Preset 0.19: up to 80% faster watch re-runs
+## Server Preset v0.19: up to 80% faster watch re-runs
 
 With the watcher behaving predictably, we could make Server Preset lean on it.
-[Version 0.19](https://github.com/eddeee888/graphql-code-generator-plugins/releases/tag/%40eddeee888%2Fgcg-typescript-resolver-files%400.19.0)
+[v0.19](https://github.com/eddeee888/graphql-code-generator-plugins/releases/tag/%40eddeee888%2Fgcg-typescript-resolver-files%400.19.0)
 uses the new watch capabilities and adds internal caching of its most expensive work: the check
 that compares resolver types against your mappers, and the schema parsing that every generates
 block used to repeat.

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -1,51 +1,33 @@
 ---
-title: Consistent Watcher, Fixed Windows, and a Faster Server Preset
+title: Consistent Watcher, a Faster Server Preset, and Fixed Windows
 authors: eddeee888
 tags: [graphql, graphql-codegen, watch-mode, server-preset, performance]
 date: 2026-09-08
 description:
-  Codegen watch mode is now consistent across file tracking, profiling, plugins and presets, and
-  Server Preset 0.19 uses it to cut watch re-runs by up to 80%.
+  Codegen watch mode is now consistent across file tracking, profiling, plugins and presets,
+  Server Preset 0.19 uses it to cut watch re-runs by up to 80%, and Windows support is improved
+  too.
 ---
 
 Watch mode in [GraphQL Code Generator](https://the-guild.dev/graphql/codegen) is now consistent
-across file tracking, profiling, plugins and presets, Windows gets a couple of watch-mode fixes of
-its own, and [Server Preset](https://github.com/eddeee888/graphql-code-generator-plugins) 0.19
-builds on all of that with internal caching to make watch re-runs up to 80% faster.
+across file tracking, profiling, plugins and presets.
+[Server Preset](https://github.com/eddeee888/graphql-code-generator-plugins) 0.19 builds on that
+with internal caching to make watch re-runs up to 80% faster, and Windows support is improved too.
 
 ## Watch mode is consistent now
 
-Watch mode used to behave differently depending on what was generating your files. Presets that
-rewrite files they previously generated could see those files removed as stale; the CLI's in-memory
-cache could drift from what was actually on disk, so real changes were skipped; `overwrite` set on a
-preset-based `generates` entry was quietly ignored; and the profiler wrote nothing at all when you
-passed `--watch`.
+Watch mode is the recommended way to work with Codegen in managed workflows like Client Preset and
+Server Preset. But the base CLI's watch-mode support wasn't consistent across plugins and presets,
+and profiling didn't work on every run.
 
-Those are fixed. File tracking now respects the settings you actually declared, plugins and presets
-can tell Codegen how their output should be compared against disk, and `codegen --profile --watch`
-writes a trace for every run, so watch mode is measurable rather than mysterious. Plugins and
-presets behave the same way here: no special cases, no per-project workarounds.
+That's fixed:
 
-{/* TODO: confirm which release carries #10936 (merged 2026-09-06, not in cli@7.4.0)
-    before publishing, or drop it from the list below */}
-
-The changes shipped across `@graphql-codegen/cli` 7.3.0, 7.3.1 and 7.4.0, in
-[#10921](https://github.com/dotansimha/graphql-code-generator/pull/10921),
-[#10924](https://github.com/dotansimha/graphql-code-generator/pull/10924),
-[#10928](https://github.com/dotansimha/graphql-code-generator/pull/10928),
-[#10930](https://github.com/dotansimha/graphql-code-generator/pull/10930) and
-[#10936](https://github.com/dotansimha/graphql-code-generator/pull/10936).
-
-## Fixed Windows
-
-Two Windows-specific watch-mode bugs are fixed: ignore patterns now always use forward slashes, so
-generated output is correctly ignored instead of being watched and re-triggering builds, and
-loading a schema or documents from a `.js`, `.cjs`, or `.mjs` file no longer crashes with an
-ESM URL-scheme error.
-
-{/* TODO: confirm release status before publishing - #10936 (ignore-glob fix) is merged but not
-    yet in a shipped cli version, and #10935 (ESM import fix) is still an open draft pinning an
-    alpha graphql-tools build; name the release(s) these ship in, or drop these claims */}
+- `overwrite.updateExistingFiles` and `overwrite.removeStaleFiles` let a preset control whether its
+  regenerated files are updated in place or removed as stale
+- `contentComparison` lets plugins and presets choose disk vs. cache comparison when deciding
+  whether to rewrite a file
+- `overwrite` set on a preset-based `generates` entry is no longer silently ignored
+- `--profile --watch` now writes a trace after every rebuild, not just the initial run
 
 ## Server Preset 0.19: up to 80% faster watch re-runs
 
@@ -59,18 +41,24 @@ schema types and mappers don't change, generation time dropped by 50 to 80% — 
 across all generates blocks, and from 3.1s to 0.6s for the Server Preset output alone. Runs where
 the schema or mappers did change still do the full work.
 
+## Fixed Windows
+
+We want Codegen to work in any environment seamlessly. Windows support has been lacking, mainly due
+to differences in how Windows handles file paths.
+
+That's fixed too:
+
+- Watch mode's ignore patterns now always use forward slashes, so generated output is correctly
+  ignored instead of being watched and re-triggering builds
+- Loading a schema or documents from a `.js`, `.cjs`, or `.mjs` file no longer crashes with an ESM
+  URL-scheme error
+
 ## Upgrading
 
 ```sh
-pnpm add -D @graphql-codegen/cli@^7.4.0 @eddeee888/gcg-typescript-resolver-files@^0.19.0
+pnpm add -D @graphql-codegen/cli@7.4.1 # Watcher and Windows fixes
+pnpm add -D @eddeee888/gcg-typescript-resolver-files@0.19.0 # Server Preset perf improvements
 ```
-
-{/* TODO: confirm we want to recommend cli@7.4.0 as the pairing - Server Preset 0.19.0
-    only peer-depends on @graphql-codegen/plugin-helpers ^7.3.0 */}
-
-That's the whole upgrade. If you previously worked around disappearing resolver files with a
-root-level `overwrite` setting, you can drop it: the preset's `defineConfig()` now sets what it
-needs on its own generates block.
 
 If watch mode still feels slow or wrong for you, run it with `--profile` and open an issue with the
 trace on [graphql-code-generator](https://github.com/dotansimha/graphql-code-generator/issues) or

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -1,0 +1,66 @@
+---
+title: Consistent Watch Mode and a Faster Server Preset
+authors: eddeee888
+tags: [graphql, graphql-codegen, watch-mode, server-preset, performance]
+date: 2026-09-08
+description:
+  Codegen watch mode is now consistent across file tracking, profiling, plugins and presets, and
+  Server Preset 0.19 uses it to cut watch re-runs by up to 80%.
+---
+
+Watch mode in [GraphQL Code Generator](https://the-guild.dev/graphql/codegen) is now consistent
+across file tracking, profiling, plugins and presets, and
+[Server Preset](https://github.com/eddeee888/graphql-code-generator-plugins) 0.19 builds on that
+with internal caching to make watch re-runs up to 80% faster.
+
+## Watch mode is consistent now
+
+Watch mode used to behave differently depending on what was generating your files. Presets that
+rewrite files they previously generated could see those files removed as stale; the CLI's in-memory
+cache could drift from what was actually on disk, so real changes were skipped; `overwrite` set on a
+preset-based `generates` entry was quietly ignored; and the profiler wrote nothing at all when you
+passed `--watch`.
+
+Those are fixed. File tracking now respects the settings you actually declared, plugins and presets
+can tell Codegen how their output should be compared against disk, and `codegen --profile --watch`
+writes a trace for every run, so watch mode is measurable rather than mysterious. Plugins and
+presets behave the same way here: no special cases, no per-project workarounds.
+
+{/* TODO: confirm which release carries #10936 (merged 2026-09-06, not in cli@7.4.0)
+    before publishing, or drop it from the list below */}
+
+The changes shipped across `@graphql-codegen/cli` 7.3.0, 7.3.1 and 7.4.0, in
+[#10921](https://github.com/dotansimha/graphql-code-generator/pull/10921),
+[#10924](https://github.com/dotansimha/graphql-code-generator/pull/10924),
+[#10928](https://github.com/dotansimha/graphql-code-generator/pull/10928),
+[#10930](https://github.com/dotansimha/graphql-code-generator/pull/10930) and
+[#10936](https://github.com/dotansimha/graphql-code-generator/pull/10936).
+
+## Server Preset 0.19: up to 80% faster watch re-runs
+
+With the watcher behaving predictably, we could make Server Preset lean on it. Version 0.19 uses the
+new watch capabilities and adds internal caching of its most expensive work: the check that compares
+resolver types against your mappers, and the schema parsing that every generates block used to
+repeat.
+
+Measured on [Hive Console](https://github.com/graphql-hive/console)'s codebase, on re-runs where
+schema types and mappers don't change, generation time dropped by 50 to 80% — from 5.6s to 2.6s
+across all generates blocks, and from 3.1s to 0.6s for the Server Preset output alone. Runs where
+the schema or mappers did change still do the full work.
+
+## Upgrading
+
+```sh
+pnpm add -D @graphql-codegen/cli@^7.4.0 @eddeee888/gcg-typescript-resolver-files@^0.19.0
+```
+
+{/* TODO: confirm we want to recommend cli@7.4.0 as the pairing - Server Preset 0.19.0
+    only peer-depends on @graphql-codegen/plugin-helpers ^7.3.0 */}
+
+That's the whole upgrade. If you previously worked around disappearing resolver files with a
+root-level `overwrite` setting, you can drop it: the preset's `defineConfig()` now sets what it
+needs on its own generates block.
+
+If watch mode still feels slow or wrong for you, run it with `--profile` and open an issue with the
+trace on [graphql-code-generator](https://github.com/dotansimha/graphql-code-generator/issues) or
+[graphql-code-generator-plugins](https://github.com/eddeee888/graphql-code-generator-plugins/issues).

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -20,26 +20,25 @@ Watch mode is the recommended way to work with Codegen in managed workflows like
 Server Preset. But the base CLI's watch-mode support wasn't consistent across plugins and presets,
 and profiling didn't work on every run.
 
-That's fixed:
+There are fixes and improvements to allow library authors more flexibility to control the output:
 
 - `overwrite.updateExistingFiles` and `overwrite.removeStaleFiles` let a preset control whether its
   regenerated files are updated in place or removed as stale
+- `overwrite` set on a preset-based `generates` entry is no longer silently ignored
 - `contentComparison` lets plugins and presets choose disk vs. cache comparison when deciding
   whether to rewrite a file
-- `overwrite` set on a preset-based `generates` entry is no longer silently ignored
 - `--profile --watch` now writes a trace after every rebuild, not just the initial run
 
 ## Server Preset 0.19: up to 80% faster watch re-runs
 
-With the watcher behaving predictably, we could make Server Preset lean on it. Version 0.19 uses the
-new watch capabilities and adds internal caching of its most expensive work: the check that compares
-resolver types against your mappers, and the schema parsing that every generates block used to
-repeat.
+With the watcher behaving predictably, we could make Server Preset lean on it.
+[Version 0.19](https://github.com/eddeee888/graphql-code-generator-plugins/releases/tag/%40eddeee888%2Fgcg-typescript-resolver-files%400.19.0)
+uses the new watch capabilities and adds internal caching of its most expensive work: the check
+that compares resolver types against your mappers, and the schema parsing that every generates
+block used to repeat.
 
 Measured on [Hive Console](https://github.com/graphql-hive/console)'s codebase, on re-runs where
-schema types and mappers don't change, generation time dropped by 50 to 80% — from 5.6s to 2.6s
-across all generates blocks, and from 3.1s to 0.6s for the Server Preset output alone. Runs where
-the schema or mappers did change still do the full work.
+schema types and mappers don't change, generation time dropped by **50 to 80%**.
 
 ## Fixed Windows
 
@@ -48,7 +47,7 @@ to differences in how Windows handles file paths.
 
 That's fixed too:
 
-- Watch mode's ignore patterns now always use forward slashes, so generated output is correctly
+- Watch mode's ignore patterns now correctly use forward slashes, so generated output is correctly
   ignored instead of being watched and re-triggering builds
 - Loading a schema or documents from a `.js`, `.cjs`, or `.mjs` file no longer crashes with an ESM
   URL-scheme error

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -2,7 +2,7 @@
 title: Consistent Watcher, a Faster Server Preset, and Fixed Windows
 authors: eddeee888
 tags: [graphql, graphql-codegen, watch-mode, server-preset, performance]
-date: 2026-09-08
+date: 2026-09-14
 description:
   Codegen watch mode is now consistent across file tracking, profiling, plugins and presets,
   Server Preset v0.19 uses it to cut watch re-runs by up to 80%, and Windows support is improved

--- a/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
+++ b/website/src/hive/documentation/content/blog/graphql-codegen-watch-mode-server-preset-202609/index.mdx
@@ -23,7 +23,7 @@ Watch mode is the recommended way to work with Codegen in managed workflows like
 But the base CLI's watch-mode support wasn't consistent across plugins and presets, and profiling
 didn't work on every run.
 
-Recent fixes and improvements allow library authors more flexibility to control the output:
+Recent patch fixed reliability issues, and added improvements allow library authors more flexibility to control the output:
 
 - `overwrite.updateExistingFiles` and `overwrite.removeStaleFiles` let a preset control whether its
   regenerated files are updated in place or removed as stale


### PR DESCRIPTION
**Before:** the watch-mode fixes in `@graphql-codegen/cli` 7.3.0–7.4.1 and Server Preset 0.19's caching live only in changelogs and PRs — anyone hitting disappearing resolver files, missed edits, slow re-runs, or Windows-specific crashes has no page saying they're fixed.

**After:** a short post announcing consistent watch mode, up to 80% faster Server Preset watch re-runs, and improved Windows support, with a one-line-per-package upgrade command.

**How:** one new post in that blog folder, matching the recent Codegen posts' frontmatter and prose; no other files change (`eddeee888` is already in `website/src/components/blog-authors.ts`); ~2 min read.

### Before merging:

- [x] Update publish date. Frontmatter date is now `2026-09-14`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a blog post detailing more consistent watch-mode behavior for file tracking, profiling, plugins, and presets.
  - Documented new overwrite and content-comparison options, plus profiling traces for every watch rebuild.
  - Highlighted Server Preset caching improvements that can reduce watch-mode rerun times by up to 80%.
  - Documented Windows fixes for ignore patterns and loading schemas or documents from JavaScript files.
  - Included upgrade guidance and troubleshooting recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
