### PR TITLE
Add Eddy Nguyen to the Hive landing page team section

### DIFF
--- a/website/src/hive/components/landing/TeamSection.astro
+++ b/website/src/hive/components/landing/TeamSection.astro
@@ -28,6 +28,7 @@ const teamMembers = [
     link: 'https://github.com/jonathanawesome',
     name: 'Jonathan Brennan',
   },
+  { github: 'eddeee888', link: 'https://github.com/eddeee888', name: 'Eddy Nguyen' },
 ] as const;
 ---
 


### PR DESCRIPTION
Adds [Eddy Nguyen](https://github.com/eddeee888) to the "Built by The Guild. Industry Veterans." section on the Hive landing page, after Jonathan, using his GitHub avatar like the other entries.

Verified with a full local build and screenshots of the section at desktop and tablet widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Eddy Nguyen to the team section, including a link to his GitHub profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->