### PR TITLE
Stop routing /graphql/envelop to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -59,11 +59,6 @@ export const jsonConfig = {
       crisp: { segments: ['tools'] },
       sitemap: true,
     },
-    '/graphql/envelop': {
-      rewrite: 'envelop.pages.dev',
-      crisp: { segments: ['envelop'] },
-      sitemap: true,
-    },
     '/graphql/shield': {
       redirect: 'https://github.com/maticzav/graphql-shield',
       status: 302,


### PR DESCRIPTION
Removes the `/graphql/envelop` rewrite to `envelop.pages.dev` from the website router, so Envelop pages are served by this repo's Pages deployment like Hive, Codegen, Yoga, and Mesh.

**Merge last**, after the Envelop website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every Envelop URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Removed routing for `/graphql/envelop`; requests to this path are no longer rewritten to the Envelop site or included in the sitemap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->