### PR TITLE
docs(router): update docs for recent compression changes

### DIFF
--- a/website/src/hive/documentation/content/docs/router/configuration/traffic_shaping.mdx
+++ b/website/src/hive/documentation/content/docs/router/configuration/traffic_shaping.mdx
@@ -480,6 +480,15 @@ option above, which controls compression between the client and the router.
   every subgraph, independent of whether outbound compression is enabled.
 </Callout>
 
+<Callout type="info">
+  A subgraph response with `Content-Encoding: identity` (the [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-identity-2)
+  token meaning "no encoding"), or with an empty `Content-Encoding` value, is
+  treated the same as a response with no `Content-Encoding` header at all: the
+  body is passed through unchanged rather than failing with a decompression
+  error. Only an unrecognized compression algorithm surfaces a decompression
+  error.
+</Callout>
+
 ```yaml title="router.config.yaml"
 traffic_shaping:
   all:

--- a/website/src/hive/documentation/content/docs/router/observability/logging.mdx
+++ b/website/src/hive/documentation/content/docs/router/observability/logging.mdx
@@ -81,7 +81,9 @@ when a request finishes. This is the router's access log. It uses the
 | `error_code`            | Response error code, when applicable.                                                                                                                     |
 | `response_mode`         | How the response was delivered (single/stream).                                                                                                           |
 | `status_code`           | HTTP status code returned to the client.                                                                                                                  |
-| `payload_bytes`         | Size of the response payload in bytes. For streams, this is the total amount of data sent.                                                                |
+| `payload_bytes`         | Size of the response payload in bytes (uncompressed). For streams, this is the total amount of data sent.                                                  |
+| `response_compression`  | Algorithm the client-facing response was compressed with (`gzip`, `deflate`, `br`, or `zstd`). Omitted when the response is sent uncompressed.             |
+| `response_bytes`        | Compressed size, in bytes, actually sent over the wire. Sits next to `payload_bytes` so the two make the achieved compression ratio visible. Omitted when the response is sent uncompressed. |
 | `supergraph_identifier` | Identifier of the supergraph used to serve the request.                                                                                                   |
 | `duration_ms`           | Total time spent handling the request, in milliseconds. For streams, this is the total time since the request started until stream is stopped/terminated. |
 
@@ -108,6 +110,8 @@ Every line, including the summary, also carries the [correlation fields](#reques
   "partial_response": false,
   "status_code": 200,
   "payload_bytes": 842,
+  "response_compression": "gzip",
+  "response_bytes": 517,
   "duration_ms": 14
 }
 ```
@@ -123,6 +127,14 @@ Every line, including the summary, also carries the [correlation fields](#reques
 </Tabs.Tab>
 
 </Tabs>
+
+<Callout type="info">
+  `response_compression` and `response_bytes` are only present when the response
+  was actually compressed. They are omitted when the response is sent
+  uncompressed — because compression is disabled, the client did not advertise a
+  supported `Accept-Encoding`, or the payload was below
+  [`traffic_shaping.router.compression.response.min_size`](/docs/router/configuration/traffic_shaping#routercompressionresponsemin_size).
+</Callout>
 
 Structured logs are intentionally **flat** (no nested fields), which makes them straightforward to
 ingest and query in log management systems.


### PR DESCRIPTION
Docs for: 
https://github.com/graphql-hive/router/pull/1512
https://github.com/graphql-hive/router/pull/1514


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that outbound responses with an empty or `identity` content encoding pass through unchanged.
  - Documented access log fields for response compression and compressed response size.
  - Clarified that `payload_bytes` reports the uncompressed response size.
  - Added details on when compression metadata is omitted from logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->