### PR TITLE
Document the Hive Gateway MCP plugin

### DIFF
--- a/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
@@ -63,12 +63,3 @@ Available in operation files loaded through `operationsPath`, `operationsStr` or
 | `@mcpTool`        | Operation                  | `name`, `description`, `descriptionProvider`, `meta`                  | Registers the operation as a tool                                                        |
 | `@mcpDescription` | Variable or selected field | `provider` (`<provider>:<prompt>` or `<provider>:<prompt>:<version>`) | Sets a dynamic description for the variable or output field                              |
 | `@mcpHeader`      | Variable                   | `name`                                                                | Hides the variable from the input schema and fills it from the named HTTP request header |
-
-## Exported types
-
-`@graphql-hive/plugin-mcp` exports `useMCP`, `createLangfuseProvider` and the types `MCPConfig`,
-`MCPToolConfig`, `MCPToolSource`, `MCPToolOverrides`, `MCPToolAnnotations`, `MCPToolExecution`,
-`MCPIcon`, `MCPInputOverrides`, `MCPOutputOverrides`, `MCPToolHooks`, `ToolHookContext`,
-`MCPResourceConfig`, `MCPResourceTemplateConfig`, `ResourceTemplateResult`, `MCPAnnotations`,
-`MCPContentAnnotations`, `MCPResourceAnnotations`, `MCPOperationsLoader`, `DescriptionProvider`,
-`DescriptionProviderConfig` and `DescriptionProviderContext`.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
@@ -25,11 +25,11 @@ separately, or loaded from YAML or JSON.
 
 ## Operation sources
 
-| Option           | Type                  | Default | Description                                                                                            |
-| ---------------- | --------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `operationsPath` | `string`              |         | A `.graphql` file, or a directory of them, containing named operations and `@mcpTool` directives       |
-| `operationsStr`  | `string`              |         | The operations as a raw GraphQL string, as an alternative to a file                                    |
-| `loader`         | `MCPOperationsLoader` |         | Fetch the operations from an external source at startup, with optional live updates through `onUpdate` |
+| Option           | Type                  | Default | Description                                                                                      |
+| ---------------- | --------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `operationsPath` | `string`              |         | A `.graphql` file, or a directory of them, containing named operations and `@mcpTool` directives |
+| `operationsStr`  | `string`              |         | The operations as a raw GraphQL string, as an alternative to a file                              |
+| `loader`         | `MCPOperationsLoader` |         | Load operations for each MCP request with access to its `request` and `serverContext`             |
 
 ## Tools, resources and providers
 

--- a/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
@@ -4,6 +4,13 @@ sidebarTitle: Configuration Reference
 description: Every option of the Hive Gateway MCP plugin, its type and default.
 ---
 
+import { Callout } from '@hive/design-system/hive-components/callout'
+
+<Callout type="warning">
+  The MCP plugin is in beta. Its configuration and behavior may change between releases as the
+  protocol and the plugin evolve, and these docs are updated alongside it.
+</Callout>
+
 `useMCP(ctx, config)` takes the gateway plugin context and an `MCPConfig` object. The `MCPConfig`
 type is exported by `@graphql-hive/plugin-mcp` so a configuration can be authored and type-checked
 separately, or loaded from YAML or JSON.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/configuration.mdx
@@ -1,0 +1,74 @@
+---
+title: MCP Plugin Configuration Reference
+sidebarTitle: Configuration Reference
+description: Every option of the Hive Gateway MCP plugin, its type and default.
+---
+
+`useMCP(ctx, config)` takes the gateway plugin context and an `MCPConfig` object. The `MCPConfig`
+type is exported by `@graphql-hive/plugin-mcp` so a configuration can be authored and type-checked
+separately, or loaded from YAML or JSON.
+
+## Server options
+
+| Option            | Type        | Default        | Description                                                                        |
+| ----------------- | ----------- | -------------- | ---------------------------------------------------------------------------------- |
+| `name`            | `string`    | (required)     | Server name reported in `initialize` responses                                     |
+| `version`         | `string`    | `"1.0.0"`      | Server version reported in `initialize` responses                                  |
+| `title`           | `string`    |                | Human-readable server title                                                        |
+| `description`     | `string`    |                | Human-readable server description                                                  |
+| `instructions`    | `string`    |                | Free-text instructions included in `initialize` responses, for the model's context |
+| `icons`           | `MCPIcon[]` |                | Server icons for client UIs (`src`, `mimeType`, `sizes`, `theme`)                  |
+| `websiteUrl`      | `string`    |                | Server website URL                                                                 |
+| `protocolVersion` | `string`    | `"2025-11-25"` | MCP protocol version to advertise                                                  |
+| `path`            | `string`    | `"/mcp"`       | HTTP path of the MCP endpoint                                                      |
+| `log`             | `Logger`    |                | Logger instance; defaults to the gateway's logger                                  |
+
+## Operation sources
+
+| Option           | Type                  | Default | Description                                                                                            |
+| ---------------- | --------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `operationsPath` | `string`              |         | A `.graphql` file, or a directory of them, containing named operations and `@mcpTool` directives       |
+| `operationsStr`  | `string`              |         | The operations as a raw GraphQL string, as an alternative to a file                                    |
+| `loader`         | `MCPOperationsLoader` |         | Fetch the operations from an external source at startup, with optional live updates through `onUpdate` |
+
+## Tools, resources and providers
+
+| Option                 | Type                          | Default | Description                                                                              |
+| ---------------------- | ----------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `tools`                | `MCPToolConfig[]`             | `[]`    | Tool definitions; see [Tools](/docs/gateway/mcp/tools)                                   |
+| `resources`            | `MCPResourceConfig[]`         | `[]`    | Static resources; see [Resources](/docs/gateway/mcp/resources)                           |
+| `resourceTemplates`    | `MCPResourceTemplateConfig[]` | `[]`    | Resource templates with URI patterns and handlers                                        |
+| `providers`            | `object`                      |         | Description providers by name, e.g. `{ langfuse: {} }` or a custom `DescriptionProvider` |
+| `suppressOutputSchema` | `boolean`                     | `false` | Omit the output schema from every tool in `tools/list`                                   |
+
+## Tool definition
+
+Each entry of `tools` is an `MCPToolConfig`:
+
+| Field    | Type                 | Description                                                                                                                 |
+| -------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `name`   | `string`             | Unique tool name exposed to clients (required)                                                                              |
+| `source` | `MCPToolSource`      | `{ type: "inline", query }` or `{ type: "graphql", operationName, operationType, file? }` (required)                        |
+| `tool`   | `MCPToolOverrides`   | `title`, `description`, `descriptionProvider`, `annotations`, `icons`, `execution.taskSupport`, `_meta`                     |
+| `input`  | `MCPInputOverrides`  | `schema.properties.<variable>` with `description`, `examples`, `default`, `alias`, `hidden`, `descriptionProvider`          |
+| `output` | `MCPOutputOverrides` | `path`, `schema: false`, `contentAnnotations`, `descriptionProviders`                                                       |
+| `hooks`  | `MCPToolHooks`       | `preprocess(args, context)` and `postprocess(result, args, context)`; the context carries `toolName`, `headers` and `query` |
+
+## Directives
+
+Available in operation files loaded through `operationsPath`, `operationsStr` or a `loader`:
+
+| Directive         | Placement                  | Arguments                                                             | Effect                                                                                   |
+| ----------------- | -------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `@mcpTool`        | Operation                  | `name`, `description`, `descriptionProvider`, `meta`                  | Registers the operation as a tool                                                        |
+| `@mcpDescription` | Variable or selected field | `provider` (`<provider>:<prompt>` or `<provider>:<prompt>:<version>`) | Sets a dynamic description for the variable or output field                              |
+| `@mcpHeader`      | Variable                   | `name`                                                                | Hides the variable from the input schema and fills it from the named HTTP request header |
+
+## Exported types
+
+`@graphql-hive/plugin-mcp` exports `useMCP`, `createLangfuseProvider` and the types `MCPConfig`,
+`MCPToolConfig`, `MCPToolSource`, `MCPToolOverrides`, `MCPToolAnnotations`, `MCPToolExecution`,
+`MCPIcon`, `MCPInputOverrides`, `MCPOutputOverrides`, `MCPToolHooks`, `ToolHookContext`,
+`MCPResourceConfig`, `MCPResourceTemplateConfig`, `ResourceTemplateResult`, `MCPAnnotations`,
+`MCPContentAnnotations`, `MCPResourceAnnotations`, `MCPOperationsLoader`, `DescriptionProvider`,
+`DescriptionProviderConfig` and `DescriptionProviderContext`.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
@@ -108,7 +108,7 @@ const cms: DescriptionProvider = {
     // `context.label` carries the request's `?promptLabel=` (or the configured default), so a
     // custom provider can serve environment-specific variants the same way Langfuse does.
     const variant = context?.label ?? 'production'
-    const res = await fetch(`https://my-cms.example.com/api/${config.prompt}?variant=${variant}`)
+    const res = await fetch(`https://my-cms.example.com/api/${config.prompt}?variant=${encodeURIComponent(variant)}`)
     return res.text()
   }
 }

--- a/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
@@ -8,6 +8,11 @@ description:
 
 import { Callout } from '@hive/design-system/hive-components/callout'
 
+<Callout type="warning">
+  The MCP plugin is in beta. Its configuration and behavior may change between releases as the
+  protocol and the plugin evolve, and these docs are updated alongside it.
+</Callout>
+
 The description of a tool is what an agent reads to decide when and how to call it, so it deserves
 the same iteration as a prompt. Description providers resolve tool and field descriptions at runtime
 from an external source, so you can refine them without changing the gateway configuration. The

--- a/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
@@ -104,8 +104,11 @@ reference it with `type` set to that name:
 import type { DescriptionProvider } from '@graphql-hive/plugin-mcp'
 
 const cms: DescriptionProvider = {
-  async fetchDescription(toolName, config) {
-    const res = await fetch(`https://my-cms.example.com/api/${config.prompt}`)
+  async fetchDescription(toolName, config, context) {
+    // `context.label` carries the request's `?promptLabel=` (or the configured default), so a
+    // custom provider can serve environment-specific variants the same way Langfuse does.
+    const variant = context?.label ?? 'production'
+    const res = await fetch(`https://my-cms.example.com/api/${config.prompt}?variant=${variant}`)
     return res.text()
   }
 }
@@ -123,8 +126,9 @@ useMCP(ctx, {
 })
 ```
 
-`fetchDescription` receives the tool name and the reference configuration, and returns the
-description text.
+`fetchDescription` receives the tool name, the reference configuration (the object from
+`descriptionProvider`, so any extra fields you put there are available), and a context with the
+resolved prompt `label`. It returns the description text.
 
 ## Where descriptions come from
 

--- a/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/description-providers.mdx
@@ -1,0 +1,140 @@
+---
+title: MCP Description Providers
+sidebarTitle: Description Providers
+description:
+  Manage the descriptions agents see for Hive Gateway MCP tools and fields in Langfuse or a custom
+  service, and update them without redeploying.
+---
+
+import { Callout } from '@hive/design-system/hive-components/callout'
+
+The description of a tool is what an agent reads to decide when and how to call it, so it deserves
+the same iteration as a prompt. Description providers resolve tool and field descriptions at runtime
+from an external source, so you can refine them without changing the gateway configuration. The
+plugin ships a [Langfuse](https://langfuse.com/) provider and accepts custom ones.
+
+## Langfuse
+
+Install the client and set the credentials the provider reads from the environment:
+
+```sh npm2yarn
+npm i @langfuse/client
+```
+
+```sh
+export LANGFUSE_SECRET_KEY=sk-lf-...
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com
+```
+
+Register the provider under `providers.langfuse` and reference prompts from tools:
+
+```ts title="gateway.config.ts"
+useMCP(ctx, {
+  name: 'my-api',
+  providers: {
+    langfuse: {
+      defaults: { label: 'production' }
+    }
+  },
+  tools: [
+    {
+      name: 'get_weather',
+      source: { type: 'inline', query: '...' },
+      tool: {
+        descriptionProvider: {
+          type: 'langfuse',
+          prompt: 'get_weather_description'
+        }
+      }
+    }
+  ]
+})
+```
+
+`providers.langfuse` accepts the Langfuse client parameters (`publicKey`, `secretKey`, `baseUrl`)
+when you prefer not to use environment variables, plus `defaults` applied to every prompt lookup.
+Each reference can pin a `version` or pass extra `options` (such as `label` or `cacheTtlSeconds`).
+
+Descriptions are resolved when tools are listed, so editing a prompt in Langfuse takes effect on the
+next `tools/list`. If Langfuse is unreachable, tools keep their fallback descriptions.
+
+### Referencing prompts from directives
+
+Operation files can point at providers too, with `provider:` values of the form
+`<provider>:<prompt>` or `<provider>:<prompt>:<version>`:
+
+```graphql
+query GetWeather($location: String! @mcpDescription(provider: "langfuse:location_field_desc"))
+@mcpTool(name: "get_weather", descriptionProvider: "langfuse:get_weather_description") {
+  weather(location: $location) {
+    temperature
+    conditions @mcpDescription(provider: "langfuse:conditions_desc")
+  }
+}
+```
+
+### Labels and versions
+
+A Langfuse label selects the prompt variant tagged for an environment. Labels are resolved with this
+precedence, most specific first:
+
+1. A per-request `?promptLabel=` query parameter on the MCP endpoint
+2. The tool's `descriptionProvider.options.label`
+3. The provider's `defaults.label`
+
+```sh title="Preview the staging descriptions"
+curl "http://localhost:4000/mcp?promptLabel=staging" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+<Callout type="info">
+  Langfuse treats `version` and `label` as mutually exclusive. When a reference pins an explicit
+  `version`, the plugin drops any label before calling Langfuse: a pinned version is a deliberate
+  contract, while a label is environment-level routing.
+</Callout>
+
+## Custom providers
+
+Any object with a `fetchDescription` method works as a provider. Register it under a name and
+reference it with `type` set to that name:
+
+```ts title="gateway.config.ts"
+import type { DescriptionProvider } from '@graphql-hive/plugin-mcp'
+
+const cms: DescriptionProvider = {
+  async fetchDescription(toolName, config) {
+    const res = await fetch(`https://my-cms.example.com/api/${config.prompt}`)
+    return res.text()
+  }
+}
+
+useMCP(ctx, {
+  name: 'my-api',
+  providers: { cms },
+  tools: [
+    {
+      name: 'get_weather',
+      source: { type: 'inline', query: '...' },
+      tool: { descriptionProvider: { type: 'cms', prompt: 'get-weather' } }
+    }
+  ]
+})
+```
+
+`fetchDescription` receives the tool name and the reference configuration, and returns the
+description text.
+
+## Where descriptions come from
+
+When several sources define a description for the same tool, the first match in this list wins:
+
+1. `descriptionProvider`, resolved at runtime from Langfuse or a custom provider
+2. `tool.description` in the configuration
+3. The `description` argument of the `@mcpTool` directive
+4. The description of the field in the GraphQL schema
+
+The same order applies to variable descriptions set through
+`input.schema.properties.<variable>.descriptionProvider` and `description`, and to output fields
+through `output.descriptionProviders`.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/index.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/index.mdx
@@ -1,0 +1,191 @@
+---
+title: 'Gateway: MCP Server'
+description:
+  Expose your GraphQL API to AI agents as MCP tools and resources with the Hive Gateway MCP plugin.
+---
+
+import { Callout } from '@hive/design-system/hive-components/callout'
+import { Tabs } from '@hive/design-system/tabs'
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is the standard AI agents use
+to discover and call external tools. With the `@graphql-hive/plugin-mcp` plugin, Hive Gateway
+becomes an MCP server: you pick the GraphQL operations you want to expose, and each one becomes a
+tool that agents can list and execute, complete with typed input and output schemas derived from
+your supergraph.
+
+```text
+AI Agent  --MCP JSON-RPC-->  /mcp endpoint  --GraphQL-->  your subgraphs
+```
+
+The gateway takes care of loading the schema, generating input and output schemas, validating
+arguments and formatting responses. You only define which operations become tools. The plugin
+implements the `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read` and
+`resources/templates/list` MCP methods.
+
+<Callout type="info">
+  The plugin is available on the JavaScript distributions of Hive Gateway (the `hive-gateway` CLI
+  with a `gateway.config.ts`, or the `@graphql-hive/gateway-runtime` package). It requires Node.js
+  20 or later.
+</Callout>
+
+## Installation
+
+```sh npm2yarn
+npm i @graphql-hive/plugin-mcp
+```
+
+The package ships both CommonJS and ESM builds and needs `graphql` as a peer dependency.
+[Langfuse](https://langfuse.com/) is an optional peer dependency, only needed when you use the
+built-in [Langfuse description provider](/docs/gateway/mcp/description-providers).
+
+## Quick start
+
+Register the plugin with the operations you want to expose. The simplest tool is an inline query.
+
+<Tabs items={['Gateway CLI', 'Gateway Runtime']}>
+
+{/* Gateway CLI */}
+
+<Tabs.Tab>
+
+```ts title="gateway.config.ts"
+import { defineConfig } from '@graphql-hive/gateway'
+import { useMCP, type MCPConfig } from '@graphql-hive/plugin-mcp'
+
+const mcp: MCPConfig = {
+  name: 'my-api',
+  tools: [
+    {
+      name: 'get_users',
+      source: {
+        type: 'inline',
+        query: `query ($limit: Int) { users(limit: $limit) { id name } }`
+      }
+    }
+  ]
+}
+
+export const gatewayConfig = defineConfig({
+  plugins: ctx => [useMCP(ctx, mcp)]
+})
+```
+
+Then start the gateway as usual, for example with `hive-gateway supergraph`.
+
+</Tabs.Tab>
+
+{/* Gateway Runtime */}
+
+<Tabs.Tab>
+
+```ts title="gateway.ts"
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
+import { useMCP } from '@graphql-hive/plugin-mcp'
+
+const gateway = createGatewayRuntime({
+  supergraph: 'supergraph.graphql',
+  plugins: ctx => [
+    useMCP(ctx, {
+      name: 'my-api',
+      tools: [
+        {
+          name: 'get_users',
+          source: {
+            type: 'inline',
+            query: `query ($limit: Int) { users(limit: $limit) { id name } }`
+          }
+        }
+      ]
+    })
+  ]
+})
+```
+
+</Tabs.Tab>
+
+</Tabs>
+
+The MCP endpoint is served at `/mcp` next to your GraphQL endpoint. Change it with the `path`
+option.
+
+### Define tools with directives
+
+Instead of listing tools in the configuration, you can annotate named operations in `.graphql` files
+with the `@mcpTool` directive and point the plugin at them:
+
+```graphql title="operations/weather.graphql"
+query GetWeather($location: String!)
+@mcpTool(name: "get_weather", description: "Get current weather") {
+  weather(location: $location) {
+    temperature
+    conditions
+  }
+}
+```
+
+```ts title="gateway.config.ts"
+useMCP(ctx, {
+  name: 'my-api',
+  operationsPath: './operations'
+})
+```
+
+Every operation carrying `@mcpTool` is registered as a tool automatically. Operations without the
+directive stay available as sources for tools declared in the configuration. All operations must be
+named; anonymous operations are not supported. The [Tools](/docs/gateway/mcp/tools) page covers the
+`@mcpDescription` and `@mcpHeader` directives as well.
+
+### Define tools in YAML or JSON
+
+The configuration object is plain data, so it can live in a YAML or JSON file that you load and pass
+to `useMCP`:
+
+```yaml title="mcp.yaml"
+name: weather-api
+version: 1.0.0
+
+tools:
+  - name: get_weather
+    source:
+      type: inline
+      query: |
+        query GetWeather($location: String!) {
+          weather(location: $location) {
+            temperature
+            conditions
+          }
+        }
+    tool:
+      title: Current Weather
+```
+
+## Try it out
+
+MCP speaks JSON-RPC over HTTP, so `curl` is enough to check the server:
+
+```sh title="List the tools"
+curl http://localhost:4000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+```sh title="Call a tool"
+curl http://localhost:4000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_weather","arguments":{"location":"London"}}}'
+```
+
+Point any MCP client (an IDE assistant, an agent framework, or the MCP Inspector) at
+`http://localhost:4000/mcp` to use the tools interactively.
+
+## Next steps
+
+- [Tools](/docs/gateway/mcp/tools): tool sources, directives, input and output shaping, hooks and
+  annotations.
+- [Resources and dynamic operations](/docs/gateway/mcp/resources): serve documents alongside your
+  tools and load operations from an external source at runtime.
+- [Description providers](/docs/gateway/mcp/description-providers): manage tool and field
+  descriptions in Langfuse or your own service.
+- [Configuration reference](/docs/gateway/mcp/configuration): every option of the plugin.
+- [Runnable examples](https://github.com/graphql-hive/gateway/tree/main/packages/plugins/mcp/examples)
+  in the Hive Gateway repository.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/index.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/index.mdx
@@ -13,14 +13,21 @@ becomes an MCP server: you pick the GraphQL operations you want to expose, and e
 tool that agents can list and execute, complete with typed input and output schemas derived from
 your supergraph.
 
-```text
-AI Agent  --MCP JSON-RPC-->  /mcp endpoint  --GraphQL-->  your subgraphs
+```mermaid
+flowchart LR
+    agent["AI agent"] -- "MCP (JSON-RPC)" --> gateway["Hive Gateway<br/><code>/mcp</code> endpoint"]
+    gateway -- GraphQL --> subgraphs["Your subgraphs"]
 ```
 
 The gateway takes care of loading the schema, generating input and output schemas, validating
 arguments and formatting responses. You only define which operations become tools. The plugin
 implements the `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read` and
 `resources/templates/list` MCP methods.
+
+<Callout type="warning">
+  The MCP plugin is in beta. Its configuration and behavior may change between releases as the
+  protocol and the plugin evolve, and these docs are updated alongside it.
+</Callout>
 
 <Callout type="info">
   The plugin is available on the JavaScript distributions of Hive Gateway (the `hive-gateway` CLI

--- a/website/src/hive/documentation/content/docs/gateway/mcp/index.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/index.mdx
@@ -7,6 +7,11 @@ description:
 import { Callout } from '@hive/design-system/hive-components/callout'
 import { Tabs } from '@hive/design-system/tabs'
 
+<Callout type="warning">
+  The MCP plugin is in beta. Its configuration and behavior may change between releases as the
+  protocol and the plugin evolve, and these docs are updated alongside it.
+</Callout>
+
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is the standard AI agents use
 to discover and call external tools. With the `@graphql-hive/plugin-mcp` plugin, Hive Gateway
 becomes an MCP server: you pick the GraphQL operations you want to expose, and each one becomes a
@@ -23,11 +28,6 @@ The gateway takes care of loading the schema, generating input and output schema
 arguments and formatting responses. You only define which operations become tools. The plugin
 implements the `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read` and
 `resources/templates/list` MCP methods.
-
-<Callout type="warning">
-  The MCP plugin is in beta. Its configuration and behavior may change between releases as the
-  protocol and the plugin evolve, and these docs are updated alongside it.
-</Callout>
 
 <Callout type="info">
   The plugin is available on the JavaScript distributions of Hive Gateway (the `hive-gateway` CLI

--- a/website/src/hive/documentation/content/docs/gateway/mcp/meta.json
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "MCP Server",
+  "pages": [
+    "[Overview](/docs/gateway/mcp)",
+    "tools",
+    "resources",
+    "description-providers",
+    "configuration"
+  ]
+}

--- a/website/src/hive/documentation/content/docs/gateway/mcp/resources.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/resources.mdx
@@ -1,0 +1,110 @@
+---
+title: MCP Resources and Dynamic Operations
+sidebarTitle: Resources and Dynamic Operations
+description:
+  Serve static and templated MCP resources from Hive Gateway, and load tool operations from an
+  external source with live updates.
+---
+
+Besides tools, an MCP server can offer resources: documents agents read for context, such as an API
+guide or a schema. The plugin serves static resources and parameterized resource templates, and it
+can also load the operations behind your tools from an external source at runtime.
+
+## Static resources
+
+Resources are listed with `resources/list` and fetched with `resources/read`. Each one has a `uri`,
+a `name` and content from one of three sources:
+
+- `text`: an inline string
+- `blob`: inline base64-encoded binary content
+- `file`: a path read from disk at startup
+
+```ts title="gateway.config.ts"
+useMCP(ctx, {
+  name: 'my-api',
+  resources: [
+    {
+      name: 'api-guide',
+      uri: 'docs://api-guide',
+      mimeType: 'text/markdown',
+      text: '# API Guide\n\nUse get_users to fetch user data.'
+    },
+    {
+      name: 'icon',
+      uri: 'files://icon.png',
+      mimeType: 'image/png',
+      blob: 'iVBOR...'
+    },
+    {
+      name: 'schema',
+      uri: 'files://schema.graphql',
+      file: './schema.graphql'
+    }
+  ]
+})
+```
+
+`mimeType` defaults to `text/plain`. For `file` resources the plugin reads the file as text or as
+binary based on the MIME type; set `binary` explicitly to override. Resources also accept `title`,
+`description`, `icons`, `annotations` (`audience`, `priority`, `lastModified`) and a
+`descriptionProvider`.
+
+## Resource templates
+
+A resource template describes a family of resources with a URI pattern. Placeholders in
+`uriTemplate` become the parameters of a `handler` that produces the content on demand:
+
+```ts title="gateway.config.ts"
+useMCP(ctx, {
+  name: 'my-api',
+  resourceTemplates: [
+    {
+      uriTemplate: 'users://{id}',
+      name: 'User Profile',
+      description: 'Get a user profile by ID',
+      mimeType: 'application/json',
+      handler: async params => ({
+        text: JSON.stringify({ id: params['id'], source: 'gateway' })
+      })
+    }
+  ]
+})
+```
+
+Templates are listed with `resources/templates/list`. The handler returns either `text` or `blob`,
+optionally with a `mimeType` override for that response.
+
+## Dynamic operations loader
+
+Instead of shipping operation files with the gateway, a `loader` fetches the operations source from
+anywhere (a CDN, an object store, a persisted-documents service) when the gateway starts, and can
+subscribe to updates:
+
+```ts title="gateway.config.ts"
+useMCP(ctx, {
+  name: 'my-api',
+  loader: {
+    async load() {
+      const res = await fetch('https://my-cdn.example.com/operations.graphql')
+      return res.text()
+    },
+    onUpdate(callback) {
+      const interval = setInterval(async () => {
+        const res = await fetch('https://my-cdn.example.com/operations.graphql')
+        callback(await res.text())
+      }, 60_000)
+      return () => clearInterval(interval)
+    }
+  }
+})
+```
+
+- `load()` is called once at startup and returns the raw GraphQL source, which may contain several
+  operations. Tools declared with `@mcpTool` in that source are registered, and the other operations
+  are available to `source.type: "graphql"` tools.
+- `onUpdate` is called after a successful `load()`. Invoke the callback with the full new source
+  whenever it changes; the plugin re-parses it and rebuilds the tool registry. Return a cleanup
+  function to unsubscribe when the plugin is disposed.
+- If `load()` rejects, the error is logged, `onUpdate` is not called, and the gateway keeps running
+  with the tools from the other sources. Implement retries inside `load()` if you need automatic
+  recovery.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/resources.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/resources.mdx
@@ -6,6 +6,13 @@ description:
   external source per request.
 ---
 
+import { Callout } from '@hive/design-system/hive-components/callout'
+
+<Callout type="warning">
+  The MCP plugin is in beta. Its configuration and behavior may change between releases as the
+  protocol and the plugin evolve, and these docs are updated alongside it.
+</Callout>
+
 Besides tools, an MCP server can offer resources: documents agents read for context, such as an API
 guide or a schema. The plugin serves static resources and parameterized resource templates, and it
 can also load the operations behind your tools from an external source at runtime.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/resources.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/resources.mdx
@@ -3,7 +3,7 @@ title: MCP Resources and Dynamic Operations
 sidebarTitle: Resources and Dynamic Operations
 description:
   Serve static and templated MCP resources from Hive Gateway, and load tool operations from an
-  external source with live updates.
+  external source per request.
 ---
 
 Besides tools, an MCP server can offer resources: documents agents read for context, such as an API
@@ -76,35 +76,80 @@ optionally with a `mimeType` override for that response.
 
 ## Dynamic operations loader
 
-Instead of shipping operation files with the gateway, a `loader` fetches the operations source from
-anywhere (a CDN, an object store, a persisted-documents service) when the gateway starts, and can
-subscribe to updates:
+Instead of shipping operation files with the gateway, a `loader` can fetch the operations source
+from anywhere, such as a CDN, object store or persisted-documents service:
 
 ```ts title="gateway.config.ts"
 useMCP(ctx, {
   name: 'my-api',
   loader: {
-    async load() {
-      const res = await fetch('https://my-cdn.example.com/operations.graphql')
+    async load({ request, serverContext }) {
+      const tenant = encodeURIComponent(request.headers.get('x-tenant') ?? 'default')
+      const res = await fetch(`https://my-cdn.example.com/${tenant}/operations.graphql`)
       return res.text()
-    },
-    onUpdate(callback) {
-      const interval = setInterval(async () => {
-        const res = await fetch('https://my-cdn.example.com/operations.graphql')
-        callback(await res.text())
-      }, 60_000)
-      return () => clearInterval(interval)
     }
   }
 })
 ```
 
-- `load()` is called once at startup and returns the raw GraphQL source, which may contain several
-  operations. Tools declared with `@mcpTool` in that source are registered, and the other operations
-  are available to `source.type: "graphql"` tools.
-- `onUpdate` is called after a successful `load()`. Invoke the callback with the full new source
-  whenever it changes; the plugin re-parses it and rebuilds the tool registry. Return a cleanup
-  function to unsubscribe when the plugin is disposed.
-- If `load()` rejects, the error is logged, `onUpdate` is not called, and the gateway keeps running
-  with the tools from the other sources. Implement retries inside `load()` if you need automatic
-  recovery.
+`load()` runs for every MCP request and receives its `request` and `serverContext`, so the source can
+vary by tenant or any other request data. It returns raw GraphQL source, which may contain several
+operations. Operations carrying `@mcpTool` are registered as tools; the others are available to
+`source.type: "graphql"` tools.
+
+The plugin caches each resulting tool registry by the returned string. Returning an identical source
+reuses the cached registry without parsing and rebuilding it. The cache is cleared whenever the
+GraphQL schema changes. If `load()` throws, the plugin logs the error and uses only the statically
+configured tools for that request.
+
+## Load persisted documents from Hive
+
+`createHiveLoader` resolves an app deployment manifest from the Hive CDN, fetches every persisted
+GraphQL document in it, and returns the documents as one operations source for the plugin to parse:
+
+```ts title="gateway.config.ts"
+import { createHiveLoader } from '@graphql-hive/plugin-mcp/loaders/hive'
+
+useMCP(ctx, {
+  name: 'my-api',
+  loader: createHiveLoader(ctx, {
+    endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/<target-id>',
+    accessToken: '<cdn-access-token>',
+    appDeployment: {
+      appName: 'my-app',
+      appVersion: '1.0.0'
+    }
+  })
+})
+```
+
+Pass two endpoints to fail over from the first, primary CDN to the second endpoint:
+
+```ts
+createHiveLoader(ctx, {
+  endpoint: [
+    'https://cdn.graphql-hive.com/artifacts/v1/<target-id>',
+    'https://cdn-mirror.graphql-hive.com/artifacts/v1/<target-id>'
+  ],
+  accessToken: '<cdn-access-token>',
+  appDeployment: { appName: 'my-app', appVersion: '1.0.0' }
+})
+```
+
+For multi-tenant gateways, resolve the app deployment from each request:
+
+```ts
+createHiveLoader(ctx, {
+  endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/<target-id>',
+  accessToken: '<cdn-access-token>',
+  appDeployment: ({ request }) => {
+    const appName = request.headers.get('x-app-name')
+    const appVersion = request.headers.get('x-app-version')
+    if (!appName || !appVersion) throw new Error('Missing app deployment headers')
+    return { appName, appVersion }
+  }
+})
+```
+
+With a function, the manifest and documents are fetched on every request. Identical concatenated
+sources still reuse the plugin's cached tool registry.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
@@ -111,7 +111,7 @@ A tool can load its operation from a specific file instead of the global `operat
 
 `operationsStr` accepts the operations as a string instead of a file path, and the
 [dynamic loader](/docs/gateway/mcp/resources#dynamic-operations-loader) fetches them from anywhere
-at startup.
+for each MCP request.
 
 ### Directives in operation files
 

--- a/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
@@ -46,7 +46,8 @@ executed.
   },
   hooks: {
     preprocess: (args, context) => {
-      if (!args["confirm"]) return { error: "Confirmation required" };
+      // Hooks see the original variable names, not the aliases agents use.
+      if (!args["confirmationId"]) return { error: "Confirmation required" };
       return undefined;
     },
   },

--- a/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
@@ -1,0 +1,339 @@
+---
+title: MCP Tools
+description:
+  Map GraphQL operations to MCP tools in Hive Gateway. Tool sources, directives, input and output
+  shaping, hooks and annotations.
+---
+
+import { Callout } from '@hive/design-system/hive-components/callout'
+
+A tool is one GraphQL operation exposed to agents under a name of your choice. The plugin derives
+the tool's input schema from the operation's variables and its output schema from the selection set,
+so agents know what to send and what to expect. This page walks through every part of a tool
+definition.
+
+## A complete tool definition
+
+Only `name` and `source` are required; everything else refines how the tool is presented and
+executed.
+
+```ts title="gateway.config.ts"
+{
+  name: "cancel_order",
+  source: {
+    type: "inline",
+    query: `mutation ($orderId: String!, $confirmationId: String) {
+      cancelOrder(orderId: $orderId, confirmationId: $confirmationId) { success message }
+    }`,
+  },
+  tool: {
+    title: "Cancel Order",
+    description: "Cancel a pending order by ID",
+    annotations: { destructiveHint: true, idempotentHint: false },
+    execution: { taskSupport: "optional" },
+  },
+  input: {
+    schema: {
+      properties: {
+        orderId: { description: "The order ID to cancel", examples: ["ORD-123"] },
+        confirmationId: { alias: "confirm", description: "Confirmation code" },
+      },
+    },
+  },
+  output: {
+    path: "cancelOrder",
+    contentAnnotations: { audience: ["user"], priority: 0.9 },
+  },
+  hooks: {
+    preprocess: (args, context) => {
+      if (!args["confirm"]) return { error: "Confirmation required" };
+      return undefined;
+    },
+  },
+}
+```
+
+## Tool sources
+
+The `source` tells the plugin where the GraphQL operation comes from.
+
+### Inline queries
+
+The operation is written directly in the configuration:
+
+```ts
+{
+  name: "get_users",
+  source: {
+    type: "inline",
+    query: `query ($limit: Int) { users(limit: $limit) { id name } }`,
+  },
+}
+```
+
+### Named operations from files
+
+Point the plugin at a `.graphql` file, or a directory of them, with `operationsPath`, then reference
+operations by name:
+
+```ts title="gateway.config.ts"
+useMCP(ctx, {
+  name: 'my-api',
+  operationsPath: './operations',
+  tools: [
+    {
+      name: 'get_weather',
+      source: {
+        type: 'graphql',
+        operationName: 'GetWeather',
+        operationType: 'query'
+      }
+    }
+  ]
+})
+```
+
+A tool can load its operation from a specific file instead of the global `operationsPath` with
+`source.file`:
+
+```ts
+{
+  name: "get_weather",
+  source: {
+    type: "graphql",
+    operationName: "GetWeather",
+    operationType: "query",
+    file: "./custom-operations/weather.graphql",
+  },
+}
+```
+
+`operationsStr` accepts the operations as a string instead of a file path, and the
+[dynamic loader](/docs/gateway/mcp/resources#dynamic-operations-loader) fetches them from anywhere
+at startup.
+
+### Directives in operation files
+
+Operations can declare themselves as tools with the `@mcpTool` directive, which removes the need for
+a `tools` entry:
+
+```graphql title="operations/weather.graphql"
+query QuickWeather($location: String!)
+@mcpTool(name: "quick_weather", description: "Quick weather check") {
+  weather(location: $location) {
+    temperature
+    conditions
+  }
+}
+```
+
+`@mcpTool` also accepts `descriptionProvider` (see
+[Description providers](/docs/gateway/mcp/description-providers)) and `meta`, an object passed
+through to clients as the tool's `_meta`:
+
+```graphql
+query MetaWeather($location: String!)
+@mcpTool(
+  name: "meta_weather"
+  description: "Weather with metadata"
+  meta: { entitlement: "weather_access", tags: ["read", "public"], version: 2 }
+) {
+  weather(location: $location) {
+    temperature
+  }
+}
+```
+
+When the same tool is both declared with a directive and listed in `tools`, the configuration
+entry's values win; `meta` objects are shallow-merged with the configuration taking precedence on
+conflicting keys.
+
+## Input schema
+
+### Aliases, descriptions, examples and defaults
+
+Override how each variable appears to agents under `input.schema.properties`, keyed by the GraphQL
+variable name:
+
+```ts
+{
+  name: "get_weather",
+  source: {
+    type: "inline",
+    query: `query ($location: String!) { weather(location: $location) { temperature } }`,
+  },
+  input: {
+    schema: {
+      properties: {
+        location: {
+          alias: "city",
+          description: "City name to check weather for",
+          examples: ["London", "New York"],
+          default: "London",
+        },
+      },
+    },
+  },
+}
+```
+
+Agents see a `city` parameter with the description, examples and default; the plugin maps it back to
+`location` when it executes the query.
+
+### Field descriptions from directives
+
+`@mcpDescription` attaches a description to a variable or a selected field, either inline or via a
+[description provider](/docs/gateway/mcp/description-providers):
+
+```graphql
+query GetForecast($location: String!, $days: Int)
+@mcpTool(name: "get_forecast", description: "Weather forecast") {
+  forecast(location: $location, days: $days) {
+    date
+    conditions @mcpDescription(provider: "langfuse:conditions_desc")
+  }
+}
+```
+
+### Values from HTTP headers
+
+Some variables should never come from the agent, such as a tenant or user id that your
+authentication layer puts in a header. `@mcpHeader` hides the variable from the input schema and
+fills it from the named request header on every call:
+
+```graphql
+query GetCompanyData($companyId: String! @mcpHeader(name: "x-company-id"))
+@mcpTool(name: "get_company_data") {
+  company(companyId: $companyId) {
+    id
+    name
+    plan
+  }
+}
+```
+
+If the header is missing, the tool call returns an error. When you need more control, for example to
+transform the header value or fall back to a default, hide the variable with `hidden: true` and set
+it in a `preprocess` hook:
+
+```ts
+{
+  name: "get_company_data",
+  source: { type: "inline", query: `query ($companyId: String!) { ... }` },
+  input: { schema: { properties: { companyId: { hidden: true } } } },
+  hooks: {
+    preprocess(args, { headers }) {
+      args.companyId = headers["x-company-id"] || "default-company";
+    },
+  },
+}
+```
+
+## Output
+
+### Extract part of the response
+
+By default a tool returns the whole `data` object of the GraphQL response. `output.path` narrows it
+to a nested value, and the output schema advertised in `tools/list` is narrowed to match:
+
+```ts
+{
+  name: "search_cities",
+  source: {
+    type: "inline",
+    query: `query ($query: String!) { cities(query: $query) { name country population } }`,
+  },
+  output: { path: "cities" },
+}
+```
+
+Without `path`, the agent receives `{ cities: [{ name: "London", ... }] }`; with `path: "cities"` it
+receives the array directly.
+
+### Output schema and annotations
+
+- `output.schema: false` omits the output schema for one tool. `suppressOutputSchema: true` on the
+  plugin does it for all tools. Output schemas are also omitted automatically when a tool has hooks,
+  because hooks may change the shape of the result.
+- `output.contentAnnotations` attaches MCP content annotations (`audience`, `priority`,
+  `lastModified`) to the returned content items.
+- `output.descriptionProviders` adds dynamic descriptions to output fields, keyed by dot-notation
+  path:
+
+```ts
+output: {
+  descriptionProviders: {
+    "forecast.conditions": { type: "langfuse", prompt: "conditions_desc" },
+  },
+}
+```
+
+## Hooks
+
+Hooks let you intercept a tool call before and after the GraphQL execution. Both receive a context
+with `toolName`, the request `headers` sent by the agent, and the resolved GraphQL `query`.
+
+### Preprocess
+
+`preprocess` runs before execution with the de-aliased arguments (original variable names). Return
+`undefined` to continue, or return any value to short-circuit and use it as the tool result:
+
+```ts
+{
+  name: "gated_action",
+  source: { type: "inline", query: "..." },
+  hooks: {
+    preprocess: (args, context) => {
+      if (!args["_confirmed"]) {
+        return { needsConfirmation: true };
+      }
+      return undefined;
+    },
+  },
+}
+```
+
+When `preprocess` short-circuits, `postprocess` is not called.
+
+### Postprocess
+
+`postprocess` receives the GraphQL result (after `output.path` extraction), the arguments and the
+context, and returns what the agent gets:
+
+```ts
+{
+  name: "formatted_weather",
+  source: { type: "inline", query: "..." },
+  hooks: {
+    postprocess: (result, args, context) => {
+      const data = result as { weather: { temperature: number; conditions: string } };
+      return `${data.weather.temperature}F and ${data.weather.conditions}`;
+    },
+  },
+}
+```
+
+A string result is sent as text content instead of structured content.
+
+<Callout type="info">
+  Either hook can return a raw MCP result: an object with a `content` array of MCP content items
+  (`text`, `image`, `audio`, `resource` or `resource_link`). It is passed through unchanged, which
+  lets you set fields such as `_meta` or `isError`.
+</Callout>
+
+## Annotations and task support
+
+`tool.annotations` gives clients behavioral hints, following the MCP specification:
+
+| Hint              | Meaning                                                           |
+| ----------------- | ----------------------------------------------------------------- |
+| `readOnlyHint`    | The tool does not modify its environment. Clients assume `false`. |
+| `destructiveHint` | The tool may perform destructive updates. Clients assume `true`.  |
+| `idempotentHint`  | Repeated calls with the same arguments have no extra effect.      |
+| `openWorldHint`   | The tool interacts with external entities beyond a closed domain. |
+
+`tool.execution.taskSupport` declares whether a tool supports task-augmented execution for
+long-running operations: `"forbidden"` (default), `"optional"` or `"required"`.
+
+Other presentation options on `tool` are `title`, `icons` (a list of
+`{ src, mimeType, sizes, theme }` objects for client UIs) and `_meta` for opaque metadata.

--- a/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
+++ b/website/src/hive/documentation/content/docs/gateway/mcp/tools.mdx
@@ -7,6 +7,11 @@ description:
 
 import { Callout } from '@hive/design-system/hive-components/callout'
 
+<Callout type="warning">
+  The MCP plugin is in beta. Its configuration and behavior may change between releases as the
+  protocol and the plugin evolve, and these docs are updated alongside it.
+</Callout>
+
 A tool is one GraphQL operation exposed to agents under a name of your choice. The plugin derives
 the tool's input schema from the operation's variables and its output schema from the selection set,
 so agents know what to send and what to expect. This page walks through every part of a tool

--- a/website/src/hive/documentation/content/docs/gateway/meta.json
+++ b/website/src/hive/documentation/content/docs/gateway/meta.json
@@ -12,6 +12,7 @@
     "[Monitoring / Tracing](/docs/gateway/monitoring-tracing)",
     "[Incremental Delivery (Defer & Stream)](/docs/gateway/defer-stream)",
     "[Subscriptions](/docs/gateway/subscriptions)",
+    "[MCP Server](/docs/gateway/mcp)",
     "logging-and-error-handling",
     "concurrency-and-scaling",
     "other-features",


### PR DESCRIPTION
Adds an **MCP Server** section to the Hive Gateway docs, under `/docs/gateway/mcp`, written from the `@graphql-hive/plugin-mcp` readme, its `examples/` readme and the plugin's exported types in [graphql-hive/gateway](https://github.com/graphql-hive/gateway/tree/main/packages/plugins/mcp). The section sits in the sidebar right after Subscriptions.

## Pages

- **Overview** (`/docs/gateway/mcp`): what the plugin does and which MCP methods it implements, installation, a quick start for both the gateway CLI (`gateway.config.ts`) and the runtime, tools defined with `@mcpTool` directives, YAML/JSON configuration, and `curl` calls to try the endpoint.
- **Tools**: a complete tool definition, the three sources (inline, named operations from files, directives incl. `meta`), input aliases/descriptions/defaults, `@mcpDescription`, `@mcpHeader` and hidden variables, output extraction and schema control, `preprocess`/`postprocess` hooks (incl. raw MCP results), annotations and task support.
- **Resources and Dynamic Operations**: static resources (`text`/`blob`/`file`), resource templates, and the operations `loader` with `onUpdate`.
- **Description Providers**: Langfuse setup, referencing prompts from config and directives, label vs version precedence and the `?promptLabel=` override, custom providers, and where descriptions come from.
- **Configuration Reference**: every `MCPConfig` option with type and default, the tool definition fields, the three directives, and the exported types.

Details not in the readme (default logger, directive/config merge rules, binary detection for file resources) were checked against the plugin source.

Verified with a full local build: the section renders with the Hive docs chrome, the sidebar and per-page Markdown work, and the SEO and sitemap checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new MCP Server documentation section for Hive Gateway.
  * Documented installation, configuration, runtime and CLI setup, GraphQL directives, tools, resources, operation sources, and JSON-RPC testing.
  * Added guidance for description providers, including Langfuse integration, custom providers, labels, versions, and fallback behavior.
  * Documented beta status, request-based dynamic operation loading, caching, schema invalidation, persisted documents, CDN failover, and multi-tenant deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->