### PR TITLE
Native Datadog tracing in Hive Router

### DIFF
--- a/website/src/hive/documentation/content/docs/router/configuration/telemetry.mdx
+++ b/website/src/hive/documentation/content/docs/router/configuration/telemetry.mdx
@@ -265,8 +265,8 @@ Top-level OpenTelemetry tracing configuration.
 | `max_attributes_per_span`  | `integer` | `128`   | Maximum attributes to record per span.                                                                                  |
 | `max_attributes_per_event` | `integer` | `16`    | Maximum attributes to record per span event.                                                                            |
 | `max_attributes_per_link`  | `integer` | `32`    | Maximum attributes to record per span link.                                                                             |
-| `sampling`                 | `number`  | `1.0`   | Sampling ratio between `0.0` and `1.0`. Can also be set via the `TELEMETRY_TRACING_SAMPLING_RATE` environment variable. |
-| `parent_based_sampler`     | `boolean` | `false` | Inherit sampling decisions from parent span.                                                                            |
+| `sampling`                 | `number`  | `1.0`   | Sampling ratio between `0.0` and `1.0`. Can also be set via `TELEMETRY_TRACING_SAMPLING_RATE`. With Datadog, this is the provider-wide catch-all rate. |
+| `parent_based_sampler`     | `boolean` | `false` | Inherit sampling decisions from the parent span with the generic OpenTelemetry provider. Datadog uses its native parent-aware sampler. |
 
 `propagation` - Incoming and outgoing trace context propagation formats.
 
@@ -292,14 +292,19 @@ context into outgoing requests.
 
 List of exporters used to send traces.
 
-Each item in this array defines one exporter instance, so you can configure multiple OTLP
-destinations if needed.
+Each item in this array defines one exporter instance. OTLP, stdout, Hive Console tracing, and one
+enabled native Datadog exporter can share the same tracer provider.
 
-This reference documents the OTLP exporter configuration.
+| Field     | Type      | Default | Notes                                           |
+| --------- | --------- | ------- | ----------------------------------------------- |
+| `kind`    | `string`  | -       | Exporter kind: `otlp`, `stdout`, or `datadog`. |
+| `enabled` | `boolean` | `true`  | Enables or disables this exporter.              |
+
+### `otlp`
 
 | Field             | Type                 | Default | Notes                                                                        |
 | ----------------- | -------------------- | ------- | ---------------------------------------------------------------------------- |
-| `kind`            | `string`             | -       | Exporter kind. Supported value: `otlp`.                                      |
+| `kind`            | `string`             | -       | Must be `otlp`.                                                              |
 | `enabled`         | `boolean`            | `true`  | Enables or disables this exporter.                                           |
 | `endpoint`        | `StringOrExpression` | -       | OTLP endpoint. Must be set explicitly.                                       |
 | `batch_processor` | `object`             | -       | See [`batch_processor`](#telemetry-tracing-exporters-batch-processor) below. |
@@ -357,6 +362,51 @@ telemetry:
           metadata:
             x-api-key: key
 ```
+
+### `datadog`
+
+Native Datadog tracing sends traces to a Datadog Agent and uses Datadog's provider-wide sampler.
+Only one Datadog exporter can be enabled.
+
+| Field                      | Type                 | Default | Notes                                                                                      |
+| -------------------------- | -------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `kind`                     | `string`             | -       | Must be `datadog`.                                                                         |
+| `enabled`                  | `boolean`            | `true`  | Enables or disables this exporter.                                                         |
+| `endpoint`                 | `StringOrExpression` | -       | Optional Datadog Agent trace endpoint. Normally uses port `8126`, not OTLP port `4317`.     |
+| `include_graphql_document` | `boolean`            | `false` | Records `graphql.document`, which may contain full queries and sensitive literal values.   |
+
+```yaml title="router.config.yaml"
+telemetry:
+  tracing:
+    collect:
+      sampling: 0.01
+    exporters:
+      - kind: datadog
+        endpoint:
+          expression: env("DD_TRACE_AGENT_URL")
+        include_graphql_document: false
+```
+
+When `endpoint` is omitted, Datadog uses `DD_TRACE_AGENT_URL`, `DD_AGENT_HOST`,
+`DD_TRACE_AGENT_PORT`, or its native default. Configured endpoints are resolved and validated at
+startup, but Agent reachability is not probed.
+
+`collect.sampling` overrides `DD_TRACE_SAMPLE_RATE` as Datadog's catch-all rate. More specific
+`DD_TRACE_SAMPLING_RULES`, remote configuration, and `DD_TRACE_RATE_LIMIT` still apply. Explicit
+sampling has a default ceiling of 100 retained traces per second. Datadog continues recording
+non-retained requests for request, error, and latency statistics, including when `sampling` is
+`0.0`.
+
+`parent_based_sampler` does not configure Datadog. Mixed OTLP, stdout, and Hive processors receive
+only sampled spans. `DD_TRACE_ENABLED=false` disables every processor attached to the shared
+Datadog-backed provider; set this exporter's `enabled` field to `false` to disable only Datadog.
+
+When `include_graphql_document` is `false`, suppression occurs before the shared provider, so mixed
+OTLP, stdout, and Hive processors also omit the document. The router retains its configured
+propagators and does not install Datadog-native propagation.
+
+See [Native Datadog tracing](/docs/router/observability/tracing#send-traces-through-native-datadog-tracing)
+for operational details and security guidance.
 
 </details>
 

--- a/website/src/hive/documentation/content/docs/router/observability/tracing.mdx
+++ b/website/src/hive/documentation/content/docs/router/observability/tracing.mdx
@@ -13,13 +13,13 @@ traces, how to configure OTLP, how to tune throughput, and how to debug missing 
 
 ## Choose your tracing destination
 
-Hive Router supports two common tracing paths. You can send traces directly to Hive Console through
-`telemetry.hive.tracing`, or you can send them to an OTLP-compatible backend through
-`telemetry.tracing.exporters`.
+Hive Router supports three tracing paths. You can send traces directly to Hive Console through
+`telemetry.hive.tracing`, send them to an OTLP-compatible backend through
+`telemetry.tracing.exporters`, or use native Datadog tracing through a Datadog Agent.
 
-In practice, teams already running OpenTelemetry infrastructure (Jaeger, Tempo, Datadog, Honeycomb,
-and others) usually prefer OTLP because it fits into existing telemetry pipelines and backend
-routing rules.
+Teams already running OpenTelemetry infrastructure usually prefer OTLP because it fits into existing
+collector pipelines and backend routing rules. Use native Datadog tracing when you need Datadog's
+sampling, rate limiting, remote configuration, and all-request APM statistics.
 
 ## Send traces to Hive Console
 
@@ -116,6 +116,92 @@ If gRPC export fails, metadata credentials and TLS files are usually the first p
 </Tabs.Tab>
 
 </Tabs>
+
+## Send traces through native Datadog tracing
+
+Native Datadog tracing uses the [Datadog Rust tracer](https://github.com/DataDog/dd-trace-rs) and
+sends traces to a Datadog Agent trace endpoint. This differs from sending generic OpenTelemetry data
+to a Datadog OTLP endpoint. It preserves Datadog's native sampling behavior and computes request,
+error, and latency statistics from every recorded request, including requests whose detailed traces
+are not retained.
+
+```yaml title="router.config.yaml"
+telemetry:
+  tracing:
+    collect:
+      # Retain about 1% of detailed traces while keeping all-request APM statistics
+      sampling: 0.01
+    propagation:
+      trace_context: true
+    exporters:
+      - kind: datadog
+        enabled: true
+        endpoint: http://datadog-agent:8126
+```
+
+`enabled` defaults to `true`. The `endpoint` is optional and can be a
+[`StringOrExpression`](/docs/router/configuration/expressions). When omitted, Datadog uses its
+native configuration, including `DD_TRACE_AGENT_URL`, `DD_AGENT_HOST`, and `DD_TRACE_AGENT_PORT`.
+The Agent trace endpoint normally uses port `8126`; it is not the OTLP gRPC endpoint commonly
+exposed on port `4317`.
+
+The router resolves and validates a configured endpoint at startup. An unresolved expression,
+malformed URL, unsupported Agent URL scheme, or more than one enabled Datadog exporter prevents
+startup. The router does not probe Agent connectivity. An unavailable Agent therefore does not stop
+the router from starting, and asynchronous export failures are reported through Datadog logging.
+
+<Callout type="info">
+  Native Datadog tracing requires a Datadog Agent while the router is running.
+  Sampling is performed in the router, not delegated to the Agent.
+</Callout>
+
+### Sampling and mixed exporters
+
+Hive Router uses one shared tracer provider. When a Datadog exporter is enabled, Datadog owns the
+provider-wide, parent-aware sampling decision. The router maps `collect.sampling` to Datadog's
+catch-all sample rate, overriding `DD_TRACE_SAMPLE_RATE`. More specific `DD_TRACE_SAMPLING_RULES`
+can apply before that rate, and Datadog remote configuration can update native sampling behavior.
+The router's `parent_based_sampler` option only applies to the generic OpenTelemetry provider.
+
+When explicit sampling is active, Datadog retains at most 100 detailed traces per second by default.
+Set `DD_TRACE_RATE_LIMIT` to change this ceiling. At high request rates, the retained percentage can
+be lower than `collect.sampling`, while all-request request, error, and latency statistics remain
+complete. For the same reason, `sampling: 0.0` keeps instrumentation active when Datadog is enabled:
+no detailed traces are retained, but Datadog can still compute its APM statistics.
+
+You can attach OTLP, stdout, and Hive trace processors to the same Datadog-backed provider. Those
+processors receive only sampled spans and ignore Datadog's `RecordOnly` spans. Because sampling is
+provider-wide, independent per-exporter sampling rates are not supported.
+
+`DD_TRACE_ENABLED=false` disables the Datadog tracer and every OTLP, stdout, and Hive processor on
+the shared Datadog-backed provider. To disable only Datadog, disable its router exporter instead:
+
+```yaml title="router.config.yaml"
+telemetry:
+  tracing:
+    exporters:
+      - kind: datadog
+        enabled: false
+      - kind: otlp
+        enabled: true
+        protocol: grpc
+        endpoint: https://otel-collector.example.com:4317
+```
+
+Without an enabled Datadog exporter, the router uses its generic OpenTelemetry provider and sampler.
+Router resource attributes are passed to Datadog, where native Datadog precedence applies to the
+equivalent `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` values.
+
+The router continues to use the propagation formats configured under
+`telemetry.tracing.propagation`, including W3C Trace Context. It does not install Datadog-native
+propagation. The Datadog-backed provider also uses the router's existing force-flush and shutdown
+lifecycle.
+
+For native Datadog behavior and configuration details, see the
+[`datadog-opentelemetry` API](https://docs.rs/datadog-opentelemetry/),
+[Datadog Rust tracing configuration](https://docs.datadoghq.com/tracing/trace_collection/library_config/rust/),
+[trace metrics](https://docs.datadoghq.com/tracing/metrics/metrics_namespace/), and
+[ingestion mechanisms](https://docs.datadoghq.com/tracing/trace_pipeline/ingestion_mechanisms/).
 
 ## Production baseline
 

--- a/website/src/hive/documentation/content/product-updates/2026-09-09-hive-router-native-datadog-tracing/index.mdx
+++ b/website/src/hive/documentation/content/product-updates/2026-09-09-hive-router-native-datadog-tracing/index.mdx
@@ -1,0 +1,82 @@
+---
+title: Native Datadog Tracing in Hive Router
+description:
+  Hive Router now integrates with Datadog's native Rust tracer for all-request APM statistics,
+  native sampling, and direct export through the Datadog Agent.
+date: 2026-09-09
+authors: [denis]
+---
+
+[Hive Router](/docs/router) now supports native Datadog tracing through the
+[Datadog Agent](https://docs.datadoghq.com/agent/). Unlike generic OTLP export, the integration uses
+Datadog's native Rust tracer inside the router, preserving Datadog sampling rules, rate limiting,
+remote configuration, and request, error, and latency statistics across all recorded requests.
+
+## Quick Start
+
+Point the new `datadog` exporter at your Agent's trace endpoint:
+
+```yaml title="router.config.yaml"
+telemetry:
+  tracing:
+    collect:
+      # Retain about 1% of detailed traces while keeping all-request APM statistics
+      sampling: 0.01
+    propagation:
+      trace_context: true
+    exporters:
+      - kind: datadog
+        endpoint: http://datadog-agent:8126
+```
+
+The endpoint is optional. When omitted, the tracer uses Datadog's native `DD_TRACE_AGENT_URL`,
+`DD_AGENT_HOST`, and `DD_TRACE_AGENT_PORT` configuration. Native trace intake normally uses port
+`8126`, not the OTLP gRPC port `4317`.
+
+The router validates configured endpoint values at startup but does not probe Agent connectivity.
+An Agent outage therefore cannot prevent the router from starting.
+
+## Complete APM Statistics with Controlled Trace Volume
+
+Native Datadog tracing separates all-request statistics from retained trace detail. Requests rejected
+by the detailed trace sampler are still recorded for Datadog's request counts, error rates, and
+latency distributions.
+
+Hive Router maps `telemetry.tracing.collect.sampling` to Datadog's catch-all sample rate. Datadog
+sampling rules and remote configuration can make more specific decisions, while
+`DD_TRACE_RATE_LIMIT` controls the retained-trace ceiling. The default ceiling is 100 traces per
+second when explicit sampling is active, so high-traffic routers may retain less than the configured
+percentage without losing all-request APM statistics.
+
+This also means `sampling: 0.0` keeps tracing instrumentation active when Datadog is enabled. It
+retains no detailed traces, but continues producing complete request, error, and latency statistics.
+
+## Works Alongside Existing Exporters
+
+Datadog, OTLP, stdout, and Hive Console tracing can share one tracer provider. Datadog owns the
+provider-wide sampling decision, and the other processors export only sampled spans rather than the
+`RecordOnly` spans used for Datadog statistics.
+
+Because the provider is shared, `DD_TRACE_ENABLED=false` disables every attached tracing processor.
+To disable only Datadog while keeping another exporter active, use router configuration:
+
+```yaml title="router.config.yaml"
+telemetry:
+  tracing:
+    exporters:
+      - kind: datadog
+        enabled: false
+      - kind: otlp
+        enabled: true
+        protocol: grpc
+        endpoint: https://otel-collector.example.com:4317
+```
+
+The router keeps its existing propagation configuration and telemetry shutdown lifecycle, so adding
+Datadog does not replace W3C Trace Context or change how providers are flushed.
+
+---
+
+- [Native Datadog tracing guide](/docs/router/observability/tracing#send-traces-through-native-datadog-tracing)
+- [`telemetry.tracing` configuration reference](/docs/router/configuration/telemetry#tracing)
+- [Datadog Rust tracing configuration](https://docs.datadoghq.com/tracing/trace_collection/library_config/rust/)


### PR DESCRIPTION
Impl https://github.com/graphql-hive/router/pull/1521

Documentation and a product update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring tracing sampling rates.
  * Documented OTLP, stdout, Datadog, and Hive Console tracing destinations.
  * Added setup instructions for native Datadog tracing, including exporter configuration, endpoint fallback, propagation, sampling, and enablement options.
  * Clarified mixed-exporter behavior, startup validation, resource attributes, and GraphQL document suppression.
  * Added a product update covering native Datadog tracing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->