### PR TITLE
Stop routing /graphql/inspector to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -29,11 +29,6 @@ export const jsonConfig = {
       crisp: { segments: ['scalars'] },
       sitemap: true,
     },
-    '/graphql/inspector': {
-      rewrite: 'graphql-inspector.pages.dev',
-      crisp: { segments: ['inspector'] },
-      sitemap: true,
-    },
     '/graphql/mesh': {
       rewrite: 'graphql-mesh-ai3.pages.dev',
       crisp: { segments: ['mesh'] },


### PR DESCRIPTION
Removes the `/graphql/inspector` rewrite to `graphql-inspector.pages.dev` from the website router, so Inspector pages are served by this repo's Pages deployment like Hive, Codegen, Yoga, and Envelop.

**Merge last**, after the Inspector website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every Inspector URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to `/graphql/inspector` are no longer routed to the external GraphQL Inspector site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->