### PR TITLE
Stop routing /graphql/apollo-angular to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -63,10 +63,6 @@ export const jsonConfig = {
       redirect: 'https://github.com/maticzav/graphql-shield',
       status: 302,
     },
-    '/graphql/apollo-angular': {
-      rewrite: 'apollo-angular.pages.dev',
-      sitemap: true,
-    },
     '/graphql/hive/federation-gateway-audit': {
       rewrite: 'federation-gateway-compatibility.pages.dev',
       crisp: { segments: ['hive-website'] },


### PR DESCRIPTION
Removes the `/graphql/apollo-angular` rewrite from the website router, so Apollo Angular pages are served by this repo's Pages deployment like the other products.

**Merge last**, after the Apollo Angular website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every Apollo Angular URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)