### PR TITLE
Stop routing /graphql/sofa-api to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -34,11 +34,6 @@ export const jsonConfig = {
       crisp: { segments: ['mesh'] },
       sitemap: true,
     },
-    '/graphql/sofa-api': {
-      rewrite: 'sofa.pages.dev',
-      crisp: { segments: ['sofa'] },
-      sitemap: true,
-    },
     '/graphql/tools': {
       rewrite: 'graphql-tools-8ja.pages.dev',
       crisp: { segments: ['tools'] },


### PR DESCRIPTION
Removes the `/graphql/sofa-api` rewrite from the website router, so SOFA pages are served by this repo's Pages deployment like the other products.

**Merge last**, after the SOFA website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every SOFA URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the `/graphql/sofa-api` route mapping to `sofa.pages.dev`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->