### PR TITLE
Stop routing /graphql/modules to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -49,11 +49,6 @@ export const jsonConfig = {
       crisp: { segments: ['sofa'] },
       sitemap: true,
     },
-    '/graphql/modules': {
-      rewrite: 'graphql-modules.pages.dev',
-      crisp: { segments: ['modules'] },
-      sitemap: true,
-    },
     '/graphql/tools': {
       rewrite: 'graphql-tools-8ja.pages.dev',
       crisp: { segments: ['tools'] },


### PR DESCRIPTION
Removes the `/graphql/modules` rewrite from the website router, so GraphQL Modules pages are served by this repo's Pages deployment like the other products.

**Merge last**, after the GraphQL Modules website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every GraphQL Modules URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the `/graphql/modules` URL rewrite mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->