### PR TITLE
Stop routing /graphql/config to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -39,11 +39,6 @@ export const jsonConfig = {
       crisp: { segments: ['mesh'] },
       sitemap: true,
     },
-    '/graphql/config': {
-      rewrite: 'graphql-config.pages.dev',
-      crisp: { segments: ['config'] },
-      sitemap: true,
-    },
     '/graphql/sofa-api': {
       rewrite: 'sofa.pages.dev',
       crisp: { segments: ['sofa'] },


### PR DESCRIPTION
Removes the `/graphql/config` rewrite from the website router, so GraphQL Config pages are served by this repo's Pages deployment like the other products.

**Merge last**, after the GraphQL Config website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every GraphQL Config URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to `/graphql/config` are no longer rewritten to an external destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->