### PR TITLE
Stop routing /graphql/scalars to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -24,11 +24,6 @@ export const jsonConfig = {
   } satisfies RewriteRecord,
   mappings: {
     // Rewrites
-    '/graphql/scalars': {
-      rewrite: 'graphql-scalars.pages.dev',
-      crisp: { segments: ['scalars'] },
-      sitemap: true,
-    },
     '/graphql/mesh': {
       rewrite: 'graphql-mesh-ai3.pages.dev',
       crisp: { segments: ['mesh'] },


### PR DESCRIPTION
Removes the `/graphql/scalars` rewrite from the website router, so GraphQL Scalars pages are served by this repo's Pages deployment like the other products.

**Merge last**, after the GraphQL Scalars website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every GraphQL Scalars URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `/graphql/scalars` route mapping from the website router.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->