### PR TITLE
Stop routing /graphql/stitching to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -47,13 +47,6 @@ export const jsonConfig = {
       redirect: 'https://the-guild.dev/graphql/hive/docs/gateway',
       status: 302,
     },
-    '/graphql/stitching': {
-      rewrite: 'schema-stitching-9g8.pages.dev',
-      crisp: {
-        segments: ['stitching'],
-      },
-      sitemap: true,
-    },
     '/openapi/fets': {
       rewrite: 'fets-3ku.pages.dev',
       crisp: {


### PR DESCRIPTION
Removes the `/graphql/stitching` rewrite from the website router, so Schema Stitching pages are served by this repo's Pages deployment like the other products.

**Merge last**, after the Schema Stitching website PR has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every Schema Stitching URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed routing for the `/graphql/stitching` path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->