### PR TITLE
Serve the GraphQL Scalars website from this repo

### DIFF
--- a/website/src/products/scalars/product.ts
+++ b/website/src/products/scalars/product.ts
@@ -10,8 +10,6 @@ export default {
   description: 'A collection of custom scalar types not included in base GraphQL.',
   repo: 'graphql-hive/graphql-scalars',
   branch: 'master',
-  // TEMPORARY: until graphql-hive/graphql-scalars's website-content-only branch merges.
-  contentRef: 'website-content-only',
   sections: [
     { base: '/docs', dir: 'docs', label: 'Documentation' },
     { base: '/changelog', dir: 'changelog', label: 'Changelog', breadcrumb: 'Changelog' },

--- a/website/src/products/scalars/product.ts
+++ b/website/src/products/scalars/product.ts
@@ -1,0 +1,98 @@
+import type { ProductDefinition } from '../define';
+
+// Type-only import and `satisfies`: node's type stripping drops both, so the
+// plain scripts under scripts/products can load this file without a bundler.
+export default {
+  slug: 'scalars',
+  name: 'GraphQL Scalars',
+  shortName: 'Scalars',
+  mark: 'SCL',
+  description: 'A collection of custom scalar types not included in base GraphQL.',
+  repo: 'graphql-hive/graphql-scalars',
+  branch: 'master',
+  // TEMPORARY: until graphql-hive/graphql-scalars's website-content-only branch merges.
+  contentRef: 'website-content-only',
+  sections: [
+    { base: '/docs', dir: 'docs', label: 'Documentation' },
+    { base: '/changelog', dir: 'changelog', label: 'Changelog', breadcrumb: 'Changelog' },
+  ],
+  changelog: 'CHANGELOG.md',
+  redirects: {
+    '/docs/introduction': '/docs',
+    '/docs/scalars': '/docs/scalars/account-number',
+    '/en/docs/scalars/*': '/docs/scalars/:splat',
+    '/docs/scalars/datetime': '/docs/scalars/date-time',
+    '/docs/scalars/jsonobject': '/docs/scalars/json-object',
+  },
+  llmsTagline:
+    'A collection of custom scalar types for GraphQL (dates, emails, URLs, currencies, JSON and dozens more), with validation, TypeScript types and mocks, ready to add to any schema.',
+  landing: {
+    headline: 'Scalars your schema is missing',
+    tagline:
+      'GraphQL ships with five scalars. GraphQL Scalars adds more than eighty precise, validated types for dates, identifiers, formats, and units, with mocks and TypeScript definitions.',
+    claims: ['80+ scalar types', 'Validation on input and output', 'Mocks and TypeScript included'],
+    getStarted: '/docs/quick-start',
+    featuresTitle: 'Precise types, less validation code',
+    features: [
+      {
+        title: 'Validated at the edge',
+        copy: 'Every scalar validates values on the way in and out, so resolvers work with data that is already correct.',
+        href: '/docs/scalars/email-address',
+        icon: 'safe-line',
+      },
+      {
+        title: 'Works with any server',
+        copy: 'Add the type definitions and resolvers to Apollo Server, GraphQL Yoga, Mercurius, or any graphql-js based server.',
+        href: '/docs/usage/apollo-server',
+        icon: 'server-line',
+      },
+      {
+        title: 'Mocks and types',
+        copy: 'Every scalar ships with a mock for testing and a TypeScript type for code generation.',
+        href: '/docs/usage/mocks',
+        icon: 'check',
+      },
+    ],
+    codeSample: {
+      title: 'Add a scalar in two lines',
+      copy: 'Import the type definition and its resolver, add both to the schema, and use the scalar like any built-in one.',
+      code: `import { makeExecutableSchema } from '@graphql-tools/schema';
+import { DateTimeResolver, DateTimeTypeDefinition, EmailAddressResolver } from 'graphql-scalars';
+
+const schema = makeExecutableSchema({
+  typeDefs: [
+    DateTimeTypeDefinition,
+    'scalar EmailAddress',
+    \`type User { email: EmailAddress!, createdAt: DateTime! }\`,
+  ],
+  resolvers: {
+    DateTime: DateTimeResolver,
+    EmailAddress: EmailAddressResolver,
+  },
+});`,
+      lang: 'ts',
+      href: '/docs/quick-start',
+      cta: 'Quick start',
+    },
+    links: [
+      {
+        title: 'All scalars',
+        copy: 'The full list, from AccountNumber to Void, each with its format and validation rules.',
+        href: '/docs/scalars/account-number',
+        label: 'Browse the scalars',
+      },
+      {
+        title: 'Usage',
+        copy: 'Setup with Apollo Server, GraphQL Yoga, GraphQL Tools, and code generation.',
+        href: '/docs/usage/apollo-server',
+        label: 'Usage guides',
+      },
+      {
+        title: 'Changelog',
+        copy: 'Every release and the changes it brought.',
+        href: '/changelog',
+        label: 'Changelog',
+      },
+    ],
+  },
+} satisfies ProductDefinition;


### PR DESCRIPTION
Ports [the-guild.dev/graphql/scalars](https://the-guild.dev/graphql/scalars) from its separate Nextra deployment into this site as a registry product of the shared plumbing in #1976. Upstream content PR: graphql-hive/graphql-scalars#3099.

**Stacked on #1976**: the diff shows both until that merges. The GraphQL Scalars part is the last commit, one file: `website/src/products/scalars/product.ts` (name, mark, repo, sections, redirects, landing copy).

## What it serves

- The 82 pages of the old site: landing page in the Hive brand, the docs with the Hive docs chrome, per-page Markdown, `llms.txt` / `llms-full.txt`, sitemap, search index, and redirects for every legacy URL (all 82 old sitemap URLs verified against the build). The `/changelog` page is rendered from the repo's CHANGELOG.md at build time.

## Merge order

1. graphql-hive/graphql-scalars#3099 (upstream content).
2. #1976 (shared plumbing), if not merged yet.
3. Drop the TEMPORARY `contentRef` line in `product.ts`, then merge this PR.
4. #1974, the router-mapping removal, after this PR's Pages build finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated GraphQL Scalars product page with overview content, documentation links, code samples, navigation, and repository information.
  * Added redirects to relevant GraphQL Scalars resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->