### PR TITLE
Speed up CI and clear its warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       # service re-optimizes every asset on a cold cache. Both are restored
       # here (before setup runs pnpm install).
       - name: cache playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -43,12 +43,26 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: cache astro image optimization
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: website/node_modules/.astro
           key: ${{ runner.os }}-astro-assets-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-astro-assets-
+
+      # The plugin hubs' npm metadata (scripts/lib/npm-info.ts) is reused for a
+      # day; the date in the key rolls the cache over once a day.
+      - name: npm metadata cache key
+        id: npm-info
+        run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: cache npm metadata
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: website/.cache/npm-info
+          key: ${{ runner.os }}-npm-info-${{ steps.npm-info.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-npm-info-
 
       - uses: ./.github/actions/setup
         name: setup env
@@ -101,6 +115,20 @@ jobs:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # The type check imports the fetched content and generated data, so the
+      # fetch runs here too; with the npm metadata cache warm it takes seconds.
+      - name: npm metadata cache key
+        id: npm-info
+        run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: cache npm metadata
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: website/.cache/npm-info
+          key: ${{ runner.os }}-npm-info-test-${{ steps.npm-info.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-npm-info-
+
       - uses: ./.github/actions/setup
         name: setup env
 
@@ -109,6 +137,13 @@ jobs:
 
       - name: website tests
         run: pnpm --filter website test
+
+      # Type-checks the Astro sources; off the deploy path so the build ships sooner.
+      - name: fetch website content
+        run: pnpm --filter website fetch
+
+      - name: website typecheck
+        run: pnpm --filter website check
 
       - name: helper worker typecheck
         run: pnpm --filter website-helper-worker typecheck
@@ -124,7 +159,7 @@ jobs:
           persist-credentials: false
 
       - name: cache playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -132,12 +167,26 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: cache astro image optimization
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: website/node_modules/.astro
           key: ${{ runner.os }}-astro-assets-lh-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-astro-assets-
+
+      # The plugin hubs' npm metadata (scripts/lib/npm-info.ts) is reused for a
+      # day; the date in the key rolls the cache over once a day.
+      - name: npm metadata cache key
+        id: npm-info
+        run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: cache npm metadata
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: website/.cache/npm-info
+          key: ${{ runner.os }}-npm-info-lh-${{ steps.npm-info.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-npm-info-
 
       - uses: ./.github/actions/setup
         name: setup env
@@ -152,7 +201,7 @@ jobs:
 
       - name: upload lighthouse reports
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lighthouse-reports
           path: .lighthouseci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
 
       # Type-checks the Astro sources; off the deploy path so the build ships sooner.
       - name: fetch website content
-        run: pnpm --filter website fetch
+        run: pnpm --filter website run fetch-all
 
       - name: website typecheck
         run: pnpm --filter website check

--- a/.github/workflows/codegen-docs-preview.yaml
+++ b/.github/workflows/codegen-docs-preview.yaml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: cache playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: cache astro image optimization
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: website/node_modules/.astro
           key: ${{ runner.os }}-astro-assets-codegen-${{ github.sha }}

--- a/.github/workflows/inspector-docs-preview.yaml
+++ b/.github/workflows/inspector-docs-preview.yaml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: cache playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: cache astro image optimization
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: website/node_modules/.astro
           key: ${{ runner.os }}-astro-assets-inspector-${{ github.sha }}

--- a/.github/workflows/product-docs-preview.yaml
+++ b/.github/workflows/product-docs-preview.yaml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: cache playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -50,7 +50,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: cache astro image optimization
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: website/node_modules/.astro
           key: ${{ runner.os }}-astro-assets-${{ env.DOCS_PREVIEW_PRODUCT }}-${{ github.sha }}

--- a/.github/workflows/yoga-docs-preview.yaml
+++ b/.github/workflows/yoga-docs-preview.yaml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: cache playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: cache astro image optimization
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: website/node_modules/.astro
           key: ${{ runner.os }}-astro-assets-yoga-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ website/public/graphql/inspector/
 # Fetched content of the registry products (scripts/products/fetch-content.ts)
 website/src/products/*/content/
 website/public/graphql/*/assets/
+
+# Cross-build caches (npm metadata for the plugin hubs, scripts/lib/npm-info.ts)
+website/.cache/

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -9,7 +9,7 @@
         "http://localhost:4321/graphql/hive",
         "http://localhost:4321/graphql/hive/docs/gateway"
       ],
-      "numberOfRuns": 3,
+      "numberOfRuns": 2,
       "settings": { "preset": "desktop" }
     },
     "assert": {

--- a/website/package.json
+++ b/website/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm run fetch:codegen && pnpm run fetch:yoga && pnpm run fetch:envelop && pnpm run fetch:inspector && pnpm run fetch:products && astro check && astro build && pnpm run postbuild:hive && pnpm run postbuild:codegen && pnpm run postbuild:yoga && pnpm run postbuild:envelop && pnpm run postbuild:inspector && pnpm run postbuild:products && pnpm run postbuild:verify",
+    "build": "pnpm run fetch && astro build && pnpm run postbuild:hive && pnpm run postbuild:codegen && pnpm run postbuild:yoga && pnpm run postbuild:envelop && pnpm run postbuild:inspector && pnpm run postbuild:products && pnpm run postbuild:verify",
     "check": "astro check",
     "check-seo": "node scripts/hive/check-seo.ts",
     "dev": "astro dev",
+    "fetch": "node scripts/fetch-all.ts",
     "fetch:codegen": "node scripts/codegen/fetch-content.ts && node scripts/codegen/fetch-npm-info.ts",
     "fetch:envelop": "node scripts/envelop/fetch-content.ts && node scripts/envelop/fetch-plugins.ts",
     "fetch:inspector": "node scripts/inspector/fetch-content.ts",

--- a/website/package.json
+++ b/website/package.json
@@ -4,11 +4,11 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm run fetch && astro build && pnpm run postbuild:hive && pnpm run postbuild:codegen && pnpm run postbuild:yoga && pnpm run postbuild:envelop && pnpm run postbuild:inspector && pnpm run postbuild:products && pnpm run postbuild:verify",
+    "build": "pnpm run fetch-all && astro build && pnpm run postbuild:hive && pnpm run postbuild:codegen && pnpm run postbuild:yoga && pnpm run postbuild:envelop && pnpm run postbuild:inspector && pnpm run postbuild:products && pnpm run postbuild:verify",
     "check": "astro check",
     "check-seo": "node scripts/hive/check-seo.ts",
     "dev": "astro dev",
-    "fetch": "node scripts/fetch-all.ts",
+    "fetch-all": "node scripts/fetch-all.ts",
     "fetch:codegen": "node scripts/codegen/fetch-content.ts && node scripts/codegen/fetch-npm-info.ts",
     "fetch:envelop": "node scripts/envelop/fetch-content.ts && node scripts/envelop/fetch-plugins.ts",
     "fetch:inspector": "node scripts/inspector/fetch-content.ts",

--- a/website/scripts/codegen/fetch-npm-info.ts
+++ b/website/scripts/codegen/fetch-npm-info.ts
@@ -4,11 +4,20 @@
  * src/codegen/generated/npm-info.json (gitignored). Run after
  * fetch-content.ts. Failures degrade to placeholder entries so a flaky npm
  * response can't take the build down — the affected page just misses its
- * download count / readme until the next deploy.
+ * download count / readme until the next deploy. Results are reused from
+ * .cache/npm-info for a day (see scripts/lib/npm-info.ts).
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  fetchPackage,
+  inBatches,
+  loadNpmInfoCache,
+  placeholderInfo,
+  saveNpmInfoCache,
+  type NpmInfo,
+} from '../lib/npm-info.ts';
 
 const projectDir = fileURLToPath(new URL('../..', import.meta.url));
 const generatedDir = join(projectDir, 'src/codegen/generated');
@@ -18,94 +27,39 @@ if (!existsSync(registryPath)) {
   throw new Error('plugins-registry.json missing — run fetch-content.ts first');
 }
 
-interface NpmInfo {
-  createdAt: string;
-  description: string;
-  license: string;
-  readme: string;
-  updatedAt: string;
-  version: string;
-  weeklyNPMDownloads: number;
-}
-
 const registry = JSON.parse(readFileSync(registryPath, 'utf8')) as Record<
   string,
   { npmPackage: string }
 >;
 
-async function fetchJson(url: string, attempts = 3): Promise<unknown> {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`${response.status} for ${url}`);
-      return await response.json();
-    } catch (error) {
-      if (attempt >= attempts) throw error;
-      // npm rate-limits bursts with 429s; back off harder for those.
-      const rateLimited = (error as Error).message.startsWith('429');
-      await new Promise(resolve => setTimeout(resolve, attempt * (rateLimited ? 5000 : 2000)));
-    }
-  }
-}
-
-async function fetchPackage(npmPackage: string): Promise<NpmInfo> {
-  const encoded = encodeURIComponent(npmPackage);
-  const [pkg, downloads] = await Promise.all([
-    fetchJson(`https://registry.npmjs.org/${encoded}`) as Promise<{
-      description?: string;
-      'dist-tags'?: { latest?: string };
-      license?: string;
-      readme?: string;
-      time?: Record<string, string>;
-      versions?: Record<string, { license?: string }>;
-    }>,
-    fetchJson(`https://api.npmjs.org/downloads/point/last-week/${encoded}`, 5).catch(error => {
-      // A zero here shows up as missing download counts on the site — warn
-      // so a throttled run is visible in the build log.
-      console.warn(`downloads fetch failed for ${npmPackage}: ${(error as Error).message}`);
-      return { downloads: 0 };
-    }) as Promise<{ downloads?: number }>,
-  ]);
-  const version = pkg['dist-tags']?.latest ?? '';
-  const readme = pkg.readme ?? '';
-  return {
-    createdAt: pkg.time?.created ?? '',
-    description: pkg.description ?? '',
-    license: pkg.license ?? pkg.versions?.[version]?.license ?? 'MIT',
-    readme: readme === 'ERROR: No README data found!' ? '' : readme,
-    updatedAt: (version && pkg.time?.[version]) || pkg.time?.modified || '',
-    version,
-    weeklyNPMDownloads: downloads.downloads ?? 0,
-  };
-}
-
+const cache = loadNpmInfoCache('codegen');
 const entries = Object.entries(registry);
 const info: Record<string, NpmInfo> = {};
+const fetched: Record<string, NpmInfo> = {};
 let failed = 0;
+let reused = 0;
 
-// Modest concurrency; the registry throttles bursts.
-const CONCURRENCY = 2;
-for (let index = 0; index < entries.length; index += CONCURRENCY) {
-  await Promise.all(
-    entries.slice(index, index + CONCURRENCY).map(async ([key, { npmPackage }]) => {
-      try {
-        info[key] = await fetchPackage(npmPackage);
-      } catch (error) {
-        failed++;
-        console.warn(`npm info failed for ${npmPackage}: ${(error as Error).message}`);
-        info[key] = {
-          createdAt: '',
-          description: '',
-          license: 'MIT',
-          readme: '',
-          updatedAt: '',
-          version: '',
-          weeklyNPMDownloads: 0,
-        };
-      }
-    }),
-  );
-}
+await inBatches(entries, async ([key, { npmPackage }]) => {
+  const cached = cache.packages[npmPackage];
+  if (cached) {
+    info[key] = cached;
+    reused++;
+    return;
+  }
+  try {
+    info[key] = fetched[npmPackage] = await fetchPackage(npmPackage, 'MIT');
+  } catch (error) {
+    failed++;
+    console.warn(`npm info failed for ${npmPackage}: ${(error as Error).message}`);
+    info[key] = placeholderInfo('MIT');
+  }
+});
 
 writeFileSync(join(generatedDir, 'npm-info.json'), `${JSON.stringify(info, null, 2)}\n`);
-console.log(`npm info for ${entries.length} packages (${failed} fallbacks)`);
+// A fresh cache keeps its date so it still expires on schedule; a full fetch starts a new day.
+saveNpmInfoCache('codegen', {
+  fetchedAt: reused > 0 ? cache.fetchedAt : new Date().toISOString(),
+  packages: { ...cache.packages, ...fetched },
+  readmes: {},
+});
+console.log(`npm info for ${entries.length} packages (${reused} from cache, ${failed} fallbacks)`);

--- a/website/scripts/codegen/fetch-npm-info.ts
+++ b/website/scripts/codegen/fetch-npm-info.ts
@@ -56,9 +56,9 @@ await inBatches(entries, async ([key, { npmPackage }]) => {
 });
 
 writeFileSync(join(generatedDir, 'npm-info.json'), `${JSON.stringify(info, null, 2)}\n`);
-// A fresh cache keeps its date so it still expires on schedule; a full fetch starts a new day.
+// A fresh cache keeps its date so it still expires on schedule; an empty one starts today.
 saveNpmInfoCache('codegen', {
-  fetchedAt: reused > 0 ? cache.fetchedAt : new Date().toISOString(),
+  fetchedAt: cache.fetchedAt || new Date().toISOString(),
   packages: { ...cache.packages, ...fetched },
   readmes: {},
 });

--- a/website/scripts/envelop/fetch-plugins.ts
+++ b/website/scripts/envelop/fetch-plugins.ts
@@ -7,11 +7,21 @@
  *    Inngest, the Hive client), merged into src/envelop/generated/readmes.json
  * Failures degrade to placeholders so a flaky registry can't take the build
  * down — the affected page just misses its download count or shows the npm
- * readme until the next deploy.
+ * readme until the next deploy. Results are reused from .cache/npm-info for
+ * a day (see scripts/lib/npm-info.ts).
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  fetchPackage,
+  fetchWithRetry,
+  inBatches,
+  loadNpmInfoCache,
+  placeholderInfo,
+  saveNpmInfoCache,
+  type NpmInfo,
+} from '../lib/npm-info.ts';
 import { absolutizeReadmeLinks } from './readme-links.ts';
 
 const projectDir = fileURLToPath(new URL('../..', import.meta.url));
@@ -23,116 +33,68 @@ if (!existsSync(registryPath)) {
   throw new Error('plugins-registry.json missing — run fetch-content.ts first');
 }
 
-interface NpmInfo {
-  createdAt: string;
-  description: string;
-  license: string;
-  readme: string;
-  updatedAt: string;
-  version: string;
-  weeklyNPMDownloads: number;
-}
-
 const registry = JSON.parse(readFileSync(registryPath, 'utf8')) as {
   plugins: Record<string, { npmPackage: string; readme?: { path?: string; repo?: string } }>;
 };
 const readmes = JSON.parse(readFileSync(readmesPath, 'utf8')) as Record<string, string>;
 
-async function fetchWithRetry(url: string, attempts = 3): Promise<Response> {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`${response.status} for ${url}`);
-      return response;
-    } catch (error) {
-      if (attempt >= attempts) throw error;
-      // npm rate-limits bursts with 429s; back off harder for those.
-      const rateLimited = (error as Error).message.startsWith('429');
-      await new Promise(resolve => setTimeout(resolve, attempt * (rateLimited ? 5000 : 2000)));
-    }
-  }
-}
-const fetchJson = async (url: string, attempts?: number) =>
-  (await fetchWithRetry(url, attempts)).json() as Promise<unknown>;
-
-async function fetchPackage(npmPackage: string): Promise<NpmInfo> {
-  const encoded = encodeURIComponent(npmPackage);
-  const [pkg, downloads] = await Promise.all([
-    fetchJson(`https://registry.npmjs.org/${encoded}`) as Promise<{
-      description?: string;
-      'dist-tags'?: { latest?: string };
-      license?: string;
-      readme?: string;
-      time?: Record<string, string>;
-      versions?: Record<string, { license?: string }>;
-    }>,
-    fetchJson(`https://api.npmjs.org/downloads/point/last-week/${encoded}`, 5).catch(error => {
-      console.warn(`downloads fetch failed for ${npmPackage}: ${(error as Error).message}`);
-      return { downloads: 0 };
-    }) as Promise<{ downloads?: number }>,
-  ]);
-  const version = pkg['dist-tags']?.latest ?? '';
-  const readme = pkg.readme ?? '';
-  return {
-    createdAt: pkg.time?.created ?? '',
-    description: pkg.description ?? '',
-    license: pkg.license ?? pkg.versions?.[version]?.license ?? '',
-    readme: readme === 'ERROR: No README data found!' ? '' : readme,
-    updatedAt: (version && pkg.time?.[version]) || pkg.time?.modified || '',
-    version,
-    weeklyNPMDownloads: downloads.downloads ?? 0,
-  };
-}
-
+const cache = loadNpmInfoCache('envelop');
 const entries = Object.entries(registry.plugins);
 const info: Record<string, NpmInfo> = {};
+const fetched: Record<string, NpmInfo> = {};
+const fetchedReadmes: Record<string, string> = {};
 let failed = 0;
-let fetchedReadmes = 0;
+let reused = 0;
 
-// Modest concurrency; the registry throttles bursts.
-const CONCURRENCY = 2;
-for (let index = 0; index < entries.length; index += CONCURRENCY) {
-  await Promise.all(
-    entries.slice(index, index + CONCURRENCY).map(async ([key, { npmPackage, readme }]) => {
-      try {
-        info[key] = await fetchPackage(npmPackage);
-      } catch (error) {
-        failed++;
-        console.warn(`npm info failed for ${npmPackage}: ${(error as Error).message}`);
-        info[key] = {
-          createdAt: '',
-          description: '',
-          license: '',
-          readme: '',
-          updatedAt: '',
-          version: '',
-          weeklyNPMDownloads: 0,
-        };
-      }
-      // Same caution as fetch-content.ts: the registry may come from a PR, so
-      // only well-formed GitHub coordinates are fetched.
-      const validSource =
-        readme?.repo !== undefined &&
-        readme.path !== undefined &&
-        /^[\w.-]+\/[\w.-]+$/.test(readme.repo) &&
-        !readme.path.split('/').some(segment => segment === '..' || segment === '');
-      if (!readmes[key] && validSource) {
-        try {
-          const response = await fetchWithRetry(
-            `https://raw.githubusercontent.com/${readme.repo}/HEAD/${readme.path}`,
-          );
-          readmes[key] = absolutizeReadmeLinks(await response.text(), readme.repo!, readme.path!);
-          fetchedReadmes++;
-        } catch (error) {
-          console.warn(`readme fetch failed for ${key}: ${(error as Error).message}`);
-        }
-      }
-    }),
-  );
-}
+await inBatches(entries, async ([key, { npmPackage, readme }]) => {
+  const cached = cache.packages[npmPackage];
+  if (cached) {
+    info[key] = cached;
+    reused++;
+  } else {
+    try {
+      info[key] = fetched[npmPackage] = await fetchPackage(npmPackage, '');
+    } catch (error) {
+      failed++;
+      console.warn(`npm info failed for ${npmPackage}: ${(error as Error).message}`);
+      info[key] = placeholderInfo('');
+    }
+  }
+  if (readmes[key]) return;
+  if (cache.readmes[key]) {
+    readmes[key] = cache.readmes[key];
+    return;
+  }
+  // Same caution as fetch-content.ts: the registry may come from a PR, so
+  // only well-formed GitHub coordinates are fetched.
+  const validSource =
+    readme?.repo !== undefined &&
+    readme.path !== undefined &&
+    /^[\w.-]+\/[\w.-]+$/.test(readme.repo) &&
+    !readme.path.split('/').some(segment => segment === '..' || segment === '');
+  if (!validSource) return;
+  try {
+    const response = await fetchWithRetry(
+      `https://raw.githubusercontent.com/${readme.repo}/HEAD/${readme.path}`,
+    );
+    readmes[key] = fetchedReadmes[key] = absolutizeReadmeLinks(
+      await response.text(),
+      readme.repo!,
+      readme.path!,
+    );
+  } catch (error) {
+    console.warn(`readme fetch failed for ${key}: ${(error as Error).message}`);
+  }
+});
 
 writeFileSync(join(generatedDir, 'npm-info.json'), `${JSON.stringify(info, null, 2)}\n`);
 writeFileSync(readmesPath, `${JSON.stringify(readmes, null, 2)}\n`);
+// A fresh cache keeps its date so it still expires on schedule; a full fetch starts a new day.
+saveNpmInfoCache('envelop', {
+  fetchedAt: reused > 0 ? cache.fetchedAt : new Date().toISOString(),
+  packages: { ...cache.packages, ...fetched },
+  readmes: { ...cache.readmes, ...fetchedReadmes },
+});
 console.log(
-  `npm info for ${entries.length} plugins (${failed} fallbacks), ${fetchedReadmes} readmes fetched from other repos`,
+  `npm info for ${entries.length} plugins (${reused} from cache, ${failed} fallbacks), ${Object.keys(fetchedReadmes).length} readmes fetched from other repos`,
 );

--- a/website/scripts/envelop/fetch-plugins.ts
+++ b/website/scripts/envelop/fetch-plugins.ts
@@ -89,9 +89,9 @@ await inBatches(entries, async ([key, { npmPackage, readme }]) => {
 
 writeFileSync(join(generatedDir, 'npm-info.json'), `${JSON.stringify(info, null, 2)}\n`);
 writeFileSync(readmesPath, `${JSON.stringify(readmes, null, 2)}\n`);
-// A fresh cache keeps its date so it still expires on schedule; a full fetch starts a new day.
+// A fresh cache keeps its date so it still expires on schedule; an empty one starts today.
 saveNpmInfoCache('envelop', {
-  fetchedAt: reused > 0 ? cache.fetchedAt : new Date().toISOString(),
+  fetchedAt: cache.fetchedAt || new Date().toISOString(),
   packages: { ...cache.packages, ...fetched },
   readmes: { ...cache.readmes, ...fetchedReadmes },
 });

--- a/website/scripts/fetch-all.ts
+++ b/website/scripts/fetch-all.ts
@@ -38,16 +38,23 @@ const children = fetches.map(name => {
   return { name, child };
 });
 
-const results = await Promise.all(
+let firstFailure: string | undefined;
+await Promise.all(
   children.map(
     ({ name, child }) =>
-      new Promise<{ name: string; code: number | null }>(resolve => {
-        child.on('close', code => resolve({ name, code }));
+      new Promise<void>(resolve => {
+        child.on('close', code => {
+          // No point finishing the other clones once one fetch has failed.
+          if (code !== 0 && !firstFailure) {
+            firstFailure = name;
+            for (const other of children) other.child.kill();
+          }
+          resolve();
+        });
       }),
   ),
 );
-const failed = results.filter(({ code }) => code !== 0);
-if (failed.length > 0) {
-  console.error(`fetch failed: ${failed.map(({ name }) => name).join(', ')}`);
+if (firstFailure) {
+  console.error(`${firstFailure} failed; the other fetches were stopped`);
   process.exit(1);
 }

--- a/website/scripts/fetch-all.ts
+++ b/website/scripts/fetch-all.ts
@@ -1,0 +1,53 @@
+/**
+ * Runs every content fetch (`fetch:*` in package.json) at once. They are
+ * independent — each clones its own repo and writes its own directories —
+ * and the two plugin hubs spend most of their time waiting on the npm
+ * registry, so running them side by side roughly halves the fetch phase.
+ * Output is prefixed per fetch; the first failure stops the rest.
+ */
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const projectDir = fileURLToPath(new URL('..', import.meta.url));
+const { scripts } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as {
+  scripts: Record<string, string>;
+};
+const fetches = Object.keys(scripts).filter(name => name.startsWith('fetch:'));
+
+const children = fetches.map(name => {
+  const label = `[${name.slice('fetch:'.length)}]`;
+  const child = spawn('pnpm', ['run', '--silent', name], {
+    cwd: projectDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const prefix = (stream: NodeJS.ReadableStream, write: (line: string) => void) => {
+    let rest = '';
+    stream.on('data', (chunk: Buffer) => {
+      rest += chunk.toString();
+      const lines = rest.split('\n');
+      rest = lines.pop() ?? '';
+      for (const line of lines) write(`${label} ${line}`);
+    });
+    stream.on('end', () => rest && write(`${label} ${rest}`));
+  };
+  prefix(child.stdout, line => console.log(line));
+  prefix(child.stderr, line => console.error(line));
+  return { name, child };
+});
+
+const results = await Promise.all(
+  children.map(
+    ({ name, child }) =>
+      new Promise<{ name: string; code: number | null }>(resolve => {
+        child.on('close', code => resolve({ name, code }));
+      }),
+  ),
+);
+const failed = results.filter(({ code }) => code !== 0);
+if (failed.length > 0) {
+  console.error(`fetch failed: ${failed.map(({ name }) => name).join(', ')}`);
+  process.exit(1);
+}

--- a/website/scripts/lib/npm-info.ts
+++ b/website/scripts/lib/npm-info.ts
@@ -1,0 +1,127 @@
+/**
+ * npm registry metadata for the plugin hubs, with a cross-build cache.
+ *
+ * The registry document of a package lists every version ever published; for
+ * the Codegen plugins that is 20–27 MB each, so fetching a hundred of them is
+ * the slowest part of the build. The results change slowly (a version bump,
+ * a readme edit, the weekly download count), so they are kept in
+ * `.cache/npm-info/<hub>.json` and reused for a day. CI restores that
+ * directory between runs; set NPM_INFO_REFRESH=1 to ignore it.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface NpmInfo {
+  createdAt: string;
+  description: string;
+  license: string;
+  readme: string;
+  updatedAt: string;
+  version: string;
+  weeklyNPMDownloads: number;
+}
+
+export interface NpmInfoCache {
+  /** When the packages below were last fetched in full. */
+  fetchedAt: string;
+  /** Keyed by npm package name. Only successful fetches are stored. */
+  packages: Record<string, NpmInfo>;
+  /** Readmes fetched from other GitHub repos, keyed by plugin id. */
+  readmes: Record<string, string>;
+}
+
+const cacheDir = fileURLToPath(new URL('../../.cache/npm-info', import.meta.url));
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Modest concurrency; the registry throttles bursts. */
+export const CONCURRENCY = 2;
+
+export function loadNpmInfoCache(hub: string): NpmInfoCache {
+  const file = join(cacheDir, `${hub}.json`);
+  const empty: NpmInfoCache = { fetchedAt: '', packages: {}, readmes: {} };
+  if (process.env.NPM_INFO_REFRESH || !existsSync(file)) return empty;
+  try {
+    const cache = JSON.parse(readFileSync(file, 'utf8')) as Partial<NpmInfoCache>;
+    const age = Date.now() - Date.parse(cache.fetchedAt ?? '');
+    if (!(age >= 0 && age < TTL_MS)) return empty;
+    return {
+      fetchedAt: cache.fetchedAt!,
+      packages: cache.packages ?? {},
+      readmes: cache.readmes ?? {},
+    };
+  } catch {
+    return empty;
+  }
+}
+
+export function saveNpmInfoCache(hub: string, cache: NpmInfoCache): void {
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(join(cacheDir, `${hub}.json`), `${JSON.stringify(cache)}\n`);
+}
+
+export async function fetchWithRetry(url: string, attempts = 3): Promise<Response> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`${response.status} for ${url}`);
+      return response;
+    } catch (error) {
+      if (attempt >= attempts) throw error;
+      // npm rate-limits bursts with 429s; back off harder for those.
+      const rateLimited = (error as Error).message.startsWith('429');
+      await new Promise(resolve => setTimeout(resolve, attempt * (rateLimited ? 5000 : 2000)));
+    }
+  }
+}
+
+export const fetchJson = async (url: string, attempts = 3): Promise<unknown> =>
+  (await fetchWithRetry(url, attempts)).json() as Promise<unknown>;
+
+export async function fetchPackage(npmPackage: string, licenseFallback: string): Promise<NpmInfo> {
+  const encoded = encodeURIComponent(npmPackage);
+  const [pkg, downloads] = await Promise.all([
+    fetchJson(`https://registry.npmjs.org/${encoded}`) as Promise<{
+      description?: string;
+      'dist-tags'?: { latest?: string };
+      license?: string;
+      readme?: string;
+      time?: Record<string, string>;
+      versions?: Record<string, { license?: string }>;
+    }>,
+    fetchJson(`https://api.npmjs.org/downloads/point/last-week/${encoded}`, 5).catch(error => {
+      // A zero here shows up as missing download counts on the site — warn
+      // so a throttled run is visible in the build log.
+      console.warn(`downloads fetch failed for ${npmPackage}: ${(error as Error).message}`);
+      return { downloads: 0 };
+    }) as Promise<{ downloads?: number }>,
+  ]);
+  const version = pkg['dist-tags']?.latest ?? '';
+  const readme = pkg.readme ?? '';
+  return {
+    createdAt: pkg.time?.created ?? '',
+    description: pkg.description ?? '',
+    license: pkg.license ?? pkg.versions?.[version]?.license ?? licenseFallback,
+    readme: readme === 'ERROR: No README data found!' ? '' : readme,
+    updatedAt: (version && pkg.time?.[version]) || pkg.time?.modified || '',
+    version,
+    weeklyNPMDownloads: downloads.downloads ?? 0,
+  };
+}
+
+export const placeholderInfo = (licenseFallback: string): NpmInfo => ({
+  createdAt: '',
+  description: '',
+  license: licenseFallback,
+  readme: '',
+  updatedAt: '',
+  version: '',
+  weeklyNPMDownloads: 0,
+});
+
+/** Runs `work` over `items`, at most CONCURRENCY at a time. */
+export async function inBatches<T>(items: T[], work: (item: T) => Promise<void>): Promise<void> {
+  for (let index = 0; index < items.length; index += CONCURRENCY) {
+    await Promise.all(items.slice(index, index + CONCURRENCY).map(work));
+  }
+}

--- a/website/scripts/lib/npm-info.ts
+++ b/website/scripts/lib/npm-info.ts
@@ -63,7 +63,8 @@ export function saveNpmInfoCache(hub: string, cache: NpmInfoCache): void {
 export async function fetchWithRetry(url: string, attempts = 3): Promise<Response> {
   for (let attempt = 1; ; attempt++) {
     try {
-      const response = await fetch(url);
+      // A stalled registry request would otherwise hold its whole batch.
+      const response = await fetch(url, { signal: AbortSignal.timeout(60_000) });
       if (!response.ok) throw new Error(`${response.status} for ${url}`);
       return response;
     } catch (error) {

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -42,15 +42,17 @@ function generateHiveId({ entry }: { entry: string }) {
 
 /**
  * Hive frontmatter schemas, derived from the shapes every consumer was
- * previously asserting with `as` casts. passthrough() keeps unknown legacy
+ * previously asserting with `as` casts. looseObject() keeps unknown legacy
  * keys instead of stripping them; unions reflect real frontmatter variance
  * in the 400+ migrated files (string vs array authors, string vs date).
  */
 const hiveAuthor = z.union([
   z.string(),
-  z
-    .object({ avatar: z.string().optional(), name: z.string(), position: z.string().optional() })
-    .passthrough(),
+  z.looseObject({
+    avatar: z.string().optional(),
+    name: z.string(),
+    position: z.string().optional(),
+  }),
 ]);
 // String dates must be ISO days — the product-updates page sorts them
 // lexically and parses them with `new Date(`${date}T00:00:00Z`)`.
@@ -62,13 +64,11 @@ const docs = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
-  schema: z
-    .object({
-      title: z.string().optional(),
-      sidebarTitle: z.string().optional(),
-      description: z.string().optional(),
-    })
-    .passthrough(),
+  schema: z.looseObject({
+    title: z.string().optional(),
+    sidebarTitle: z.string().optional(),
+    description: z.string().optional(),
+  }),
 });
 
 const productUpdates = defineCollection({
@@ -77,15 +77,13 @@ const productUpdates = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
-  schema: z
-    .object({
-      title: z.string(),
-      description: z.string(),
-      date: hiveDate,
-      authors: z.array(hiveAuthor),
-      canonical: z.string().optional(),
-    })
-    .passthrough(),
+  schema: z.looseObject({
+    title: z.string(),
+    description: z.string(),
+    date: hiveDate,
+    authors: z.array(hiveAuthor),
+    canonical: z.string().optional(),
+  }),
 });
 
 const caseStudies = defineCollection({
@@ -94,16 +92,14 @@ const caseStudies = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
-  schema: z
-    .object({
-      title: z.string(),
-      excerpt: z.string(),
-      category: z.string(),
-      date: hiveDate,
-      authors: z.array(hiveAuthor).optional(),
-      canonical: z.string().optional(),
-    })
-    .passthrough(),
+  schema: z.looseObject({
+    title: z.string(),
+    excerpt: z.string(),
+    category: z.string(),
+    date: hiveDate,
+    authors: z.array(hiveAuthor).optional(),
+    canonical: z.string().optional(),
+  }),
 });
 
 const hiveBlog = defineCollection({
@@ -112,18 +108,16 @@ const hiveBlog = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.{md,mdx}',
   }),
-  schema: z
-    .object({
-      title: z.string(),
-      description: z.string().optional(),
-      date: hiveDate,
-      authors: z.union([z.string(), z.array(hiveAuthor)]),
-      tags: z.array(z.string()).default([]),
-      featured: z.boolean().optional(),
-      canonical: z.string().optional(),
-      ogImage: z.string().optional(),
-    })
-    .passthrough(),
+  schema: z.looseObject({
+    title: z.string(),
+    description: z.string().optional(),
+    date: hiveDate,
+    authors: z.union([z.string(), z.array(hiveAuthor)]),
+    tags: z.array(z.string()).default([]),
+    featured: z.boolean().optional(),
+    canonical: z.string().optional(),
+    ogImage: z.string().optional(),
+  }),
 });
 
 /**
@@ -133,13 +127,11 @@ const hiveBlog = defineCollection({
  */
 const codegenContentRoot = './src/codegen/content';
 
-const codegenDocsSchema = z
-  .object({
-    title: z.string().optional(),
-    sidebarTitle: z.string().optional(),
-    description: z.string().optional(),
-  })
-  .passthrough();
+const codegenDocsSchema = z.looseObject({
+  title: z.string().optional(),
+  sidebarTitle: z.string().optional(),
+  description: z.string().optional(),
+});
 
 const codegenDocs = defineCollection({
   loader: glob({
@@ -203,7 +195,7 @@ const yogaChangelogs = defineCollection({
     generateId: generateHiveId,
     pattern: '**/*.md',
   }),
-  schema: z.object({ title: z.string(), description: z.string().optional() }).passthrough(),
+  schema: z.looseObject({ title: z.string(), description: z.string().optional() }),
 });
 
 const envelopContentRoot = './src/envelop/content';


### PR DESCRIPTION
Review of the CI run for the Modules merge showed the build job spending half its time (about 2 minutes) fetching npm metadata for the Codegen and Envelop plugin hubs. Each package's registry document lists every version ever published, 20–27 MB for the Codegen plugins, and the scripts fetch two at a time. The lighthouse job, the slowest at 7.5 minutes, rebuilds the site from scratch and then runs Lighthouse three times over four URLs.

**Faster**
- The npm metadata is kept in `website/.cache/npm-info` for a day (new `scripts/lib/npm-info.ts`, shared by both hub scripts) and restored by `actions/cache` with a date-based key. Only packages missing from the cache are fetched; failures are never cached. `NPM_INFO_REFRESH=1` forces a refetch.
- The content fetches run concurrently (`scripts/fetch-all.ts`, `pnpm run fetch-all`) instead of one after another.
- `astro check` moves from the deploy build into the test job, which now fetches the content first (seconds with the cache warm) because the type check imports the generated data.
- Lighthouse runs twice instead of three times.

Locally the fetch phase drops from about 2 minutes to 5 seconds with a warm cache, and a full build takes about a minute.

**Warnings**
- `actions/cache` and `actions/upload-artifact` move to their Node 24 releases (v6.1.0, v7.0.1) in every workflow. The remaining Node 20 annotations come from the-guild-org/shared-config's `setup` and `website-cf` actions and need bumps there.
- The seven Zod `passthrough()` deprecation warnings from `astro check` are gone: Astro 7 ships Zod 4, so the schemas use `looseObject()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved website build and CI efficiency through shared daily npm metadata caching.
  * Reduced Lighthouse audit runs from three to two per collection.

* **Build & Reliability**
  * Added a unified process for fetching website content concurrently.
  * Added website content validation during CI tests.
  * Improved retry handling and fallback behavior when package metadata cannot be retrieved.

* **Maintenance**
  * Updated CI caching tools across build and documentation preview workflows.
  * Preserved compatibility with legacy content metadata during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->