### PR TITLE
Stop routing /graphql/ws to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -71,13 +71,6 @@ export const jsonConfig = {
       },
       sitemap: true,
     },
-    '/graphql/ws': {
-      rewrite: 'graphql-ws.pages.dev',
-      crisp: {
-        segments: ['ws'],
-      },
-      sitemap: true,
-    },
     '/graphql/sse': {
       rewrite: 'graphql-sse.pages.dev',
       crisp: {


### PR DESCRIPTION
Deletes the `/graphql/ws` mapping from the router config: the GraphQL over WebSocket docs are served by this repo once https://github.com/the-guild-org/website/pull/1984 is deployed, so the proxy to `graphql-ws.pages.dev` goes.

Merge last, after that PR is live (the router deploys on merge, before the Pages build finishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)