### PR TITLE
Serve the GraphQL over Server-Sent Events website from this repo

### DIFF
--- a/website/scripts/products/fetch-content.ts
+++ b/website/scripts/products/fetch-content.ts
@@ -93,6 +93,30 @@ function fetchSource(product: ProductDefinition): { dir: string; temporary: bool
   return { dir: tmp, temporary: true };
 }
 
+/**
+ * The package changelog as a page body. The page title comes from the
+ * frontmatter, so a leading package-name h1 goes; release headings that
+ * some changelog generators write as h1 (`# [2.6.0](...)`) become h2 so the
+ * page keeps a single h1. Code fences are left alone.
+ */
+function changelogBody(markdown: string): string {
+  const lines = markdown.trim().split('\n');
+  if (/^# /.test(lines[0] ?? '') && !/\d+\.\d+/.test(lines[0])) lines.shift();
+  let fence: string | null = null;
+  return lines
+    .map(line => {
+      const opening = line.match(/^\s*(`{3,}|~{3,})/);
+      if (opening) {
+        if (fence === null) fence = opening[1];
+        else if (line.trim().startsWith(fence)) fence = null;
+        return line;
+      }
+      return fence === null && line.startsWith('# ') ? `#${line}` : line;
+    })
+    .join('\n')
+    .trim();
+}
+
 for (const product of await selectedProducts()) {
   const contentDir = join(projectDir, 'src/products', product.slug, 'content');
   const publicDir = join(projectDir, 'public/graphql', product.slug);
@@ -106,10 +130,7 @@ for (const product of await selectedProducts()) {
     mkdirSync(publicDir, { recursive: true });
     cpSync(join(website, 'assets'), join(publicDir, 'assets'), { recursive: true });
     if (product.changelog) {
-      // The package changelog as a page: its own h1 goes, the title comes from frontmatter.
-      const body = readFileSync(join(source, product.changelog), 'utf8')
-        .replace(/^# .+\n+/, '')
-        .trim();
+      const body = changelogBody(readFileSync(join(source, product.changelog), 'utf8'));
       mkdirSync(join(contentDir, 'changelog'), { recursive: true });
       writeFileSync(
         join(contentDir, 'changelog', 'index.md'),

--- a/website/scripts/products/fetch-content.ts
+++ b/website/scripts/products/fetch-content.ts
@@ -101,7 +101,7 @@ function fetchSource(product: ProductDefinition): { dir: string; temporary: bool
  */
 function changelogBody(markdown: string): string {
   const lines = markdown.trim().split('\n');
-  if (/^# /.test(lines[0] ?? '') && !/\d+\.\d+/.test(lines[0])) lines.shift();
+  if (/^ {0,3}# /.test(lines[0] ?? '') && !/\d+\.\d+/.test(lines[0])) lines.shift();
   let fence: string | null = null;
   return lines
     .map(line => {
@@ -111,7 +111,8 @@ function changelogBody(markdown: string): string {
         else if (line.trim().startsWith(fence)) fence = null;
         return line;
       }
-      return fence === null && line.startsWith('# ') ? `#${line}` : line;
+      // Up to three leading spaces still make a heading.
+      return fence === null ? line.replace(/^( {0,3})# /, '$1## ') : line;
     })
     .join('\n')
     .trim();

--- a/website/src/products/sse/product.ts
+++ b/website/src/products/sse/product.ts
@@ -1,0 +1,101 @@
+import type { ProductDefinition } from '../define';
+
+// Type-only import and `satisfies`: node's type stripping drops both, so the
+// plain scripts under scripts/products can load this file without a bundler.
+export default {
+  slug: 'sse',
+  name: 'GraphQL over Server-Sent Events',
+  shortName: 'SSE',
+  mark: 'SSE',
+  description:
+    'Zero-dependency, HTTP/1 safe, simple, GraphQL over Server-Sent Events spec compliant server and client.',
+  repo: 'enisdenjo/graphql-sse',
+  branch: 'master',
+  // TEMPORARY: until enisdenjo/graphql-sse's website-content-only branch merges
+  // (https://github.com/enisdenjo/graphql-sse/pull/129, opened from a fork).
+  contentRef: 'refs/pull/129/head',
+  sections: [
+    { base: '/guides', dir: 'guides', label: 'Guides', breadcrumb: 'Guides' },
+    { base: '/docs', dir: 'docs', label: 'API Reference', breadcrumb: 'API Reference' },
+    { base: '/changelog', dir: 'changelog', label: 'Changelog', breadcrumb: 'Changelog' },
+  ],
+  changelog: 'CHANGELOG.md',
+  redirects: {
+    '/get-started': '/guides',
+    '/recipes': '/guides/recipes',
+  },
+  llmsTagline:
+    'graphql-sse is the reference implementation of the GraphQL over Server-Sent Events protocol: a zero-dependency, HTTP/1 safe server handler and client for queries, mutations and subscriptions over SSE, with adapters for http, http2, express, fastify, koa and fetch.',
+  landing: {
+    headline: 'GraphQL subscriptions over plain HTTP',
+    tagline:
+      'Zero-dependency, HTTP/1 safe, simple, spec compliant server and client. graphql-sse is the reference implementation of the GraphQL over Server-Sent Events protocol, and runs wherever a request handler does.',
+    claims: [
+      'Spec compliant, as the reference implementation',
+      'Single and distinct connection modes',
+      'Server and client in one small library',
+    ],
+    getStarted: '/guides',
+    featuresTitle: 'Streaming results, no WebSocket required',
+    features: [
+      {
+        title: 'Spec compliant',
+        copy: 'Fully compliant with the GraphQL over SSE protocol: a single connection mode that is safe for HTTP/1 servers and subscription-heavy apps, a distinct connection mode where each connection is its own subscription, and improvements over plain SSE for clarity and stability.',
+        href: '/docs/modules/common',
+        icon: 'safe-line',
+      },
+      {
+        title: 'Server and client',
+        copy: 'One zero-dependency library ships both sides. Tree-shaking and module separation keep the bundle small, and smart retry strategies let you shape reconnection to your needs.',
+        href: '/docs/modules/client',
+        icon: 'pulse-line',
+      },
+      {
+        title: 'Run everywhere',
+        copy: 'The handler is completely server agnostic, with ready-made adapters for http, http2, express, fastify, koa and the fetch API, so it runs in Node, Bun, Deno and edge runtimes alike.',
+        href: '/docs/modules/handler',
+        icon: 'server-line',
+      },
+    ],
+    codeSample: {
+      title: 'Subscribe in a few lines',
+      copy: 'Mount the handler on any HTTP server, then iterate over subscription events on the client with an async iterator; queries and mutations go through the same client.',
+      code: `import { createClient } from 'graphql-sse';
+
+const client = createClient({
+  url: 'http://localhost:4000/graphql/stream',
+});
+
+const subscription = client.iterate({
+  query: 'subscription { greetings }',
+});
+
+for await (const event of subscription) {
+  console.log(event.data); // { greetings: 'Hi' }, { greetings: 'Bonjour' }, ...
+}`,
+      lang: 'ts',
+      href: '/guides',
+      cta: 'Get started',
+    },
+    links: [
+      {
+        title: 'Recipes',
+        copy: 'Short and concise code snippets for common use cases: EventSource, Relay, urql, Apollo, auth, dynamic schemas, persisted queries and more.',
+        href: '/guides/recipes',
+        label: 'Browse the recipes',
+      },
+      {
+        title: 'API reference',
+        copy: 'Every module, function, class and interface of the client, the handler, the protocol messages and the server adapters.',
+        href: '/docs',
+        label: 'API reference',
+      },
+      {
+        title: 'Changelog',
+        copy: 'Every release and the changes it brought.',
+        href: '/changelog',
+        label: 'Changelog',
+      },
+    ],
+  },
+} satisfies ProductDefinition;


### PR DESCRIPTION
Adds `website/src/products/sse/product.ts`, the registry entry for [graphql-sse](https://github.com/enisdenjo/graphql-sse), so the shared product routes render its docs at `/graphql/sse`:

- `/guides` (Get Started) and `/guides/recipes`, the hand-written pages;
- `/docs/**`, the typedoc API reference (28 pages), now committed upstream and regenerated there on every push to master;
- `/changelog` from the repo's `CHANGELOG.md`.

Every URL of the old site resolves: the 29 API reference paths are byte-identical (`/docs/interfaces/use_express.RequestContext`, …), and `/get-started` and `/recipes` are 301s to the guides section.

Content comes from the upstream PR https://github.com/enisdenjo/graphql-sse/pull/129 (`contentRef: 'refs/pull/129/head'`, marked TEMPORARY; it was opened from a fork, hence the pull ref rather than a branch name) until that merges, after which the line goes.

Verified locally with `PRODUCTS=sse pnpm build` (sitemap, redirects, Pagefind, SEO check) and by checking all 31 old sitemap URLs against `dist`.

Rollout: this PR, then the upstream PR, then the draft router PR removes the mapping for `/graphql/sse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated product page for GraphQL SSE, including an overview, key benefits, feature highlights, code examples, and relevant links.
  - Added product navigation and redirect support for GraphQL SSE content.

- **Improvements**
  - Improved changelog formatting by preserving code blocks and consistently formatting release headings.
  - Changelog pages now handle package headings more cleanly for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->