### PR TITLE
Stop routing /graphql/sse to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -59,13 +59,6 @@ export const jsonConfig = {
       },
       sitemap: true,
     },
-    '/graphql/sse': {
-      rewrite: 'graphql-sse.pages.dev',
-      crisp: {
-        segments: ['sse'],
-      },
-      sitemap: true,
-    },
     '/openapi/fets': {
       rewrite: 'fets-3ku.pages.dev',
       crisp: {


### PR DESCRIPTION
Deletes the `/graphql/sse` mapping from the router config: the GraphQL over Server-Sent Events docs are served by this repo once https://github.com/the-guild-org/website/pull/1988 is deployed, so the proxy to `graphql-sse.pages.dev` goes.

Merge last, after that PR is live (the router deploys on merge, before the Pages build finishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)