### PR TITLE
Stop routing /graphql/eslint to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -57,13 +57,6 @@ export const jsonConfig = {
       redirect: 'https://the-guild.dev/graphql/hive/docs/gateway',
       status: 302,
     },
-    '/graphql/eslint': {
-      rewrite: 'graphql-eslint.pages.dev',
-      crisp: {
-        segments: ['graphql-eslint'],
-      },
-      sitemap: true,
-    },
     '/graphql/stitching': {
       rewrite: 'schema-stitching-9g8.pages.dev',
       crisp: {


### PR DESCRIPTION
Removes the `/graphql/eslint` rewrite from the website router, so GraphQL ESLint pages are served by this repo's Pages deployment like the other products.

**Merge last**, after the GraphQL ESLint website PR (the-guild-org/website#1986) has merged and its Pages build has finished. The router deploys on merge immediately, while Pages deploys after the build; merging this first would 404 every GraphQL ESLint URL until the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
