### PR TITLE
Stop routing /graphql/tools to the old Pages deployment

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -29,11 +29,6 @@ export const jsonConfig = {
       crisp: { segments: ['mesh'] },
       sitemap: true,
     },
-    '/graphql/tools': {
-      rewrite: 'graphql-tools-8ja.pages.dev',
-      crisp: { segments: ['tools'] },
-      sitemap: true,
-    },
     '/graphql/shield': {
       redirect: 'https://github.com/maticzav/graphql-shield',
       status: 302,


### PR DESCRIPTION
Removes the `/graphql/tools` mapping from the website-router config: once https://github.com/the-guild-org/website/pull/1987 is deployed, the GraphQL Tools site is built and served by this repo, so the rewrite to `graphql-tools-8ja.pages.dev` goes away.

Merge last, after https://github.com/the-guild-org/website/pull/1987 is deployed (upstream content: https://github.com/ardatan/graphql-tools/pull/8431).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
