### PR TITLE
Render external sidebar entries as links

### DIFF
--- a/website/src/docs/nav.ts
+++ b/website/src/docs/nav.ts
@@ -153,7 +153,7 @@ export function buildDocsNav(source: DocsNavSource): DocsNav {
           children.push(folder);
         } else if (slugs.has(slug)) {
           children.push(page(slug, bracket.title));
-        } else if (/^https?:\/\//.test(bracket.href)) {
+        } else if (/^https?:\/\//i.test(bracket.href)) {
           // A link to another site (Tools' sidebar points at Schema Stitching).
           children.push({ external: true, href: bracket.href, title: bracket.title, type: 'page' });
         }

--- a/website/src/docs/nav.ts
+++ b/website/src/docs/nav.ts
@@ -16,6 +16,8 @@ export interface DocsNavPage {
   href: string;
   title: string;
   type: 'page';
+  /** An absolute URL from a `[Title](https://…)` meta entry: opens elsewhere. */
+  external?: boolean;
 }
 
 export interface DocsNavFolder {
@@ -151,6 +153,9 @@ export function buildDocsNav(source: DocsNavSource): DocsNav {
           children.push(folder);
         } else if (slugs.has(slug)) {
           children.push(page(slug, bracket.title));
+        } else if (/^https?:\/\//.test(bracket.href)) {
+          // A link to another site (Tools' sidebar points at Schema Stitching).
+          children.push({ external: true, href: bracket.href, title: bracket.title, type: 'page' });
         }
         continue;
       }
@@ -171,8 +176,10 @@ export function buildDocsNav(source: DocsNavSource): DocsNav {
   function flatten(nodes: DocsNavNode[]): DocsNavPage[] {
     const items: DocsNavPage[] = [];
     for (const node of nodes) {
-      if (node.type === 'page') items.push(node);
-      else {
+      // External links are not pages of this site: no prev/next, no llms entry.
+      if (node.type === 'page') {
+        if (!node.external) items.push(node);
+      } else {
         if (node.href) items.push(page(hrefToSlug(node.href), node.title));
         items.push(...flatten(node.children));
       }

--- a/website/src/hive/components/DocsNavigationTree.astro
+++ b/website/src/hive/components/DocsNavigationTree.astro
@@ -32,8 +32,24 @@ function containsCurrentPath(node: DocsNavNode): boolean {
           data-active={node.href === currentPath}
           aria-current={node.href === currentPath ? 'page' : undefined}
           href={withBase(node.href)}
+          target={node.external ? '_blank' : undefined}
+          rel={node.external ? 'noreferrer' : undefined}
         >
           {node.title}
+          {node.external && (
+            <svg
+              class="ms-auto size-3.5 shrink-0 opacity-60"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7 17 17 7M8 7h9v9" />
+            </svg>
+          )}
         </a>
       );
     }


### PR DESCRIPTION
Found by @ardatan reviewing https://github.com/ardatan/graphql-tools/pull/8431: the Tools sidebar lists `[Schema Stitching](https://the-guild.dev/graphql/stitching)` in its `meta.json`, but the shared nav builder turned the absolute URL into a slug no page has and dropped the entry, so it never appeared on the live site.

An absolute `[Title](https://…)` entry now becomes a page node marked `external`, which the sidebar renders with `target="_blank"`, `rel="noreferrer"` and an arrow icon. External nodes are left out of the flat item list, so they get no prev/next links and no llms.txt entry. Verified on a local dev server with the Tools content: the link renders in the sidebar of every Tools docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation navigation now supports external HTTP(S) links, including mixed-case URL schemes.
  * External links open in a new tab with an external-link indicator.
* **Navigation**
  * External documentation links are excluded from previous/next navigation and generated LLM entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->